### PR TITLE
Remove javafx scan for coverage

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,11 +29,19 @@ task coverage(type: JacocoReport) {
     sourceDirectories.from files(sourceSets.main.allSource.srcDirs)
     classDirectories.from files(sourceSets.main.output)
     executionData.from files(jacocoTestReport.executionData)
+
     afterEvaluate {
-        classDirectories.from files(classDirectories.files.collect {
-            fileTree(dir: it, exclude: ['**/*.jar'])
+        classDirectories.setFrom files(classDirectories.files.collect {
+            fileTree(dir: it, exclude: [
+                    '**/*.jar',
+                    '**/*.fxml',
+                    '**/MainApp.class',
+                    '**/ui/**',
+                    '**/view/**',
+            ])
         })
     }
+
     reports {
         html.required = true
         xml.required = true


### PR DESCRIPTION
Currently javafx files are being scanned for coverage. This change ensures that javafx files are no longer scanned and tested for coverage