### PR TITLE
Collapse email and address labels if empty

### DIFF
--- a/src/main/java/hitlist/ui/PersonCard.java
+++ b/src/main/java/hitlist/ui/PersonCard.java
@@ -56,9 +56,18 @@ public class PersonCard extends UiPart<Region> {
         id.setText(displayedIndex + ". ");
         name.setText(person.getName().fullName);
         phone.setText(person.getPhone().value);
-        address.setText(person.getAddress().map(a -> a.value).orElse(""));
-        email.setText(person.getEmail().map(e -> e.value).orElse(""));
 
+        if (person.getAddress().isPresent()) {
+            address.setText(person.getAddress().get().value);
+        } else {
+            address.setVisible(false);
+        }
+
+        if (person.getEmail().isPresent()) {
+            email.setText(person.getEmail().get().value);
+        } else {
+            email.setVisible(false);
+        }
 
         groupList.stream()
             .filter(group -> group.hasMember(person))


### PR DESCRIPTION
This PR hides the email and address icons if the Person does not have values for them.

Fixes #156 

<img width="738" height="773" alt="image" src="https://github.com/user-attachments/assets/cb9b5df8-981d-4a30-bdbd-f585718fe597" />