### PR TITLE
Fix blank phone validation message

### DIFF
--- a/src/main/java/hitlist/logic/parser/ParserUtil.java
+++ b/src/main/java/hitlist/logic/parser/ParserUtil.java
@@ -28,8 +28,9 @@ public class ParserUtil {
     public static final String MESSAGE_INVALID_INDEX = "Index is not a non-zero unsigned integer.";
 
     /**
-     * Parses {@code oneBasedIndex} into an {@code Index} and returns it. Leading and trailing whitespaces will be
-     * trimmed.
+     * Parses {@code oneBasedIndex} into an {@code Index} and returns it.
+     * Leading and trailing whitespaces will be trimmed.
+     *
      * @throws ParseException if the specified index is invalid (not non-zero unsigned integer).
      */
     public static Index parseIndex(String oneBasedIndex) throws ParseException {
@@ -56,7 +57,7 @@ public class ParserUtil {
     }
 
     /**
-     * Parses {@code Collection<String> names} into a {@code Set<Name>}.
+     * Parses {@code Collection names} into a {@code Set}.
      */
     public static Set<Name> parseNames(Collection<String> names) throws ParseException {
         requireNonNull(names);
@@ -77,7 +78,10 @@ public class ParserUtil {
         requireNonNull(phone);
         String trimmedPhone = phone.trim();
         if (!Phone.isValidPhone(trimmedPhone)) {
-            throw new ParseException(Phone.MESSAGE_CONSTRAINTS);
+            if (trimmedPhone.isEmpty()) {
+                throw new ParseException(Phone.MESSAGE_CONSTRAINTS);
+            }
+            throw new ParseException(String.format(Phone.MESSAGE_INVALID_PHONE, trimmedPhone));
         }
         return new Phone(trimmedPhone);
     }
@@ -110,7 +114,6 @@ public class ParserUtil {
         Address validAddress = address.filter(s -> Address.isValidAddress(s.trim()))
                 .map(s -> new Address(s.trim()))
                 .orElseThrow(() -> new ParseException(Address.MESSAGE_CONSTRAINTS));
-
         return Optional.of(validAddress);
     }
 
@@ -142,7 +145,6 @@ public class ParserUtil {
         Email validEmail = email.filter(s -> Email.isValidEmail(s.trim()))
                 .map(s -> new Email(s.trim()))
                 .orElseThrow(() -> new ParseException(Email.MESSAGE_CONSTRAINTS));
-
         return Optional.of(validEmail);
     }
 

--- a/src/main/java/hitlist/model/person/Phone.java
+++ b/src/main/java/hitlist/model/person/Phone.java
@@ -11,6 +11,8 @@ public class Phone {
 
     public static final String MESSAGE_CONSTRAINTS =
             "Phone numbers should only contain numbers, and it should be at least 3 digits long";
+    public static final String MESSAGE_INVALID_PHONE =
+            "Invalid Number %1$s: " + MESSAGE_CONSTRAINTS;
     public static final String VALIDATION_REGEX = "\\d{3,}";
 
     public final String value;
@@ -22,7 +24,7 @@ public class Phone {
      */
     public Phone(String phone) {
         requireNonNull(phone);
-        checkArgument(isValidPhone(phone), MESSAGE_CONSTRAINTS);
+        checkArgument(isValidPhone(phone), String.format(MESSAGE_INVALID_PHONE, phone));
         value = phone;
     }
 

--- a/src/test/java/hitlist/logic/parser/AddCommandParserTest.java
+++ b/src/test/java/hitlist/logic/parser/AddCommandParserTest.java
@@ -42,6 +42,7 @@ import hitlist.model.person.Phone;
 import hitlist.testutil.PersonBuilder;
 
 public class AddCommandParserTest {
+
     private AddCommandParser parser = new AddCommandParser();
 
     @Test
@@ -49,15 +50,13 @@ public class AddCommandParserTest {
         Person expectedPerson = new PersonBuilder(BOB).build();
 
         // whitespace only preamble
-        assertParseSuccess(parser, PREAMBLE_WHITESPACE + NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB
-                + ADDRESS_DESC_BOB, new AddCommand(expectedPerson));
-
+        assertParseSuccess(parser, PREAMBLE_WHITESPACE + NAME_DESC_BOB + PHONE_DESC_BOB
+                + EMAIL_DESC_BOB + ADDRESS_DESC_BOB, new AddCommand(expectedPerson));
     }
 
     @Test
     public void parse_repeatedNonTagValue_failure() {
-        String validExpectedPersonString = NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB
-                + ADDRESS_DESC_BOB;
+        String validExpectedPersonString = NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + ADDRESS_DESC_BOB;
 
         // multiple names
         assertParseFailure(parser, NAME_DESC_AMY + validExpectedPersonString,
@@ -77,9 +76,10 @@ public class AddCommandParserTest {
 
         // multiple fields repeated
         assertParseFailure(parser,
-                validExpectedPersonString + PHONE_DESC_AMY + EMAIL_DESC_AMY + NAME_DESC_AMY + ADDRESS_DESC_AMY
-                        + validExpectedPersonString,
-                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_NAME, PREFIX_ADDRESS, PREFIX_EMAIL, PREFIX_PHONE));
+                validExpectedPersonString + PHONE_DESC_AMY + EMAIL_DESC_AMY + NAME_DESC_AMY
+                        + ADDRESS_DESC_AMY + validExpectedPersonString,
+                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_NAME, PREFIX_ADDRESS,
+                        PREFIX_EMAIL, PREFIX_PHONE));
 
         // invalid value followed by valid value
 
@@ -122,8 +122,8 @@ public class AddCommandParserTest {
     public void parse_optionalFieldsMissing_success() {
         // zero tags
         Person expectedPerson = new PersonBuilder(AMY).build();
-        assertParseSuccess(parser, NAME_DESC_AMY + PHONE_DESC_AMY + EMAIL_DESC_AMY + ADDRESS_DESC_AMY,
-                new AddCommand(expectedPerson));
+        assertParseSuccess(parser, NAME_DESC_AMY + PHONE_DESC_AMY + EMAIL_DESC_AMY
+                + ADDRESS_DESC_AMY, new AddCommand(expectedPerson));
     }
 
     @Test
@@ -151,7 +151,7 @@ public class AddCommandParserTest {
 
         // invalid phone
         assertParseFailure(parser, NAME_DESC_BOB + INVALID_PHONE_DESC + EMAIL_DESC_BOB + ADDRESS_DESC_BOB,
-                Phone.MESSAGE_CONSTRAINTS);
+                String.format(Phone.MESSAGE_INVALID_PHONE, "911a"));
 
         // invalid email
         assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + INVALID_EMAIL_DESC + ADDRESS_DESC_BOB,
@@ -166,8 +166,8 @@ public class AddCommandParserTest {
                 Name.MESSAGE_CONSTRAINTS);
 
         // non-empty preamble
-        assertParseFailure(parser, PREAMBLE_NON_EMPTY + NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB
-                + ADDRESS_DESC_BOB ,
+        assertParseFailure(parser, PREAMBLE_NON_EMPTY + NAME_DESC_BOB + PHONE_DESC_BOB
+                        + EMAIL_DESC_BOB + ADDRESS_DESC_BOB,
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE));
     }
 

--- a/src/test/java/hitlist/logic/parser/EditCommandParserTest.java
+++ b/src/test/java/hitlist/logic/parser/EditCommandParserTest.java
@@ -75,23 +75,28 @@ public class EditCommandParserTest {
     @Test
     public void parse_invalidValue_failure() {
         assertParseFailure(parser, "1" + INVALID_NAME_DESC, Name.MESSAGE_CONSTRAINTS); // invalid name
-        assertParseFailure(parser, "1" + INVALID_PHONE_DESC, Phone.MESSAGE_CONSTRAINTS); // invalid phone
+
+        assertParseFailure(parser, "1" + INVALID_PHONE_DESC,
+                String.format(Phone.MESSAGE_INVALID_PHONE, "911a")); // invalid phone
+
         assertParseFailure(parser, "1" + INVALID_EMAIL_DESC, Email.MESSAGE_CONSTRAINTS); // invalid email
+
         assertParseFailure(parser, "1" + INVALID_ADDRESS_DESC, Address.MESSAGE_CONSTRAINTS); // invalid address
 
         // invalid phone followed by valid email
-        assertParseFailure(parser, "1" + INVALID_PHONE_DESC + EMAIL_DESC_AMY, Phone.MESSAGE_CONSTRAINTS);
+        assertParseFailure(parser, "1" + INVALID_PHONE_DESC + EMAIL_DESC_AMY,
+                String.format(Phone.MESSAGE_INVALID_PHONE, "911a"));
 
         // multiple invalid values, but only the first invalid value is captured
-        assertParseFailure(parser, "1" + INVALID_NAME_DESC + INVALID_EMAIL_DESC + VALID_ADDRESS_AMY + VALID_PHONE_AMY,
-                Name.MESSAGE_CONSTRAINTS);
+        assertParseFailure(parser, "1" + INVALID_NAME_DESC + INVALID_EMAIL_DESC
+                + VALID_ADDRESS_AMY + VALID_PHONE_AMY, Name.MESSAGE_CONSTRAINTS);
     }
 
     @Test
     public void parse_allFieldsSpecified_success() {
         Index targetIndex = INDEX_SECOND_PERSON;
-        String userInput = targetIndex.getOneBased() + PHONE_DESC_BOB
-                + EMAIL_DESC_AMY + ADDRESS_DESC_AMY + NAME_DESC_AMY;
+        String userInput = targetIndex.getOneBased() + PHONE_DESC_BOB + EMAIL_DESC_AMY
+                + ADDRESS_DESC_AMY + NAME_DESC_AMY;
 
         EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder().withName(VALID_NAME_AMY)
                 .withPhone(VALID_PHONE_BOB).withEmail(VALID_EMAIL_AMY).withAddress(VALID_ADDRESS_AMY)
@@ -149,26 +154,22 @@ public class EditCommandParserTest {
         // valid followed by invalid
         Index targetIndex = INDEX_FIRST_PERSON;
         String userInput = targetIndex.getOneBased() + INVALID_PHONE_DESC + PHONE_DESC_BOB;
-
         assertParseFailure(parser, userInput, Messages.getErrorMessageForDuplicatePrefixes(PREFIX_PHONE));
 
         // invalid followed by valid
         userInput = targetIndex.getOneBased() + PHONE_DESC_BOB + INVALID_PHONE_DESC;
-
         assertParseFailure(parser, userInput, Messages.getErrorMessageForDuplicatePrefixes(PREFIX_PHONE));
 
         // mulltiple valid fields repeated
         userInput = targetIndex.getOneBased() + PHONE_DESC_AMY + ADDRESS_DESC_AMY + EMAIL_DESC_AMY
                 + PHONE_DESC_AMY + ADDRESS_DESC_AMY + EMAIL_DESC_AMY
                 + PHONE_DESC_BOB + ADDRESS_DESC_BOB + EMAIL_DESC_BOB;
-
         assertParseFailure(parser, userInput,
                 Messages.getErrorMessageForDuplicatePrefixes(PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS));
 
         // multiple invalid values
-        userInput = targetIndex.getOneBased() + INVALID_PHONE_DESC + INVALID_ADDRESS_DESC + INVALID_EMAIL_DESC
-                + INVALID_PHONE_DESC + INVALID_ADDRESS_DESC + INVALID_EMAIL_DESC;
-
+        userInput = targetIndex.getOneBased() + INVALID_PHONE_DESC + INVALID_ADDRESS_DESC
+                + INVALID_EMAIL_DESC + INVALID_PHONE_DESC + INVALID_ADDRESS_DESC + INVALID_EMAIL_DESC;
         assertParseFailure(parser, userInput,
                 Messages.getErrorMessageForDuplicatePrefixes(PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS));
     }

--- a/src/test/java/hitlist/logic/parser/ParserUtilPhoneMessageTest.java
+++ b/src/test/java/hitlist/logic/parser/ParserUtilPhoneMessageTest.java
@@ -11,13 +11,17 @@ public class ParserUtilPhoneMessageTest {
 
     @Test
     public void parsePhone_blankValue_throwsParseExceptionWithConstraintMessage() {
-        assertThrows(ParseException.class,
-            Phone.MESSAGE_CONSTRAINTS, () -> ParserUtil.parsePhone(""));
+        assertThrows(ParseException.class, Phone.MESSAGE_CONSTRAINTS, () -> ParserUtil.parsePhone(""));
     }
 
     @Test
     public void parsePhone_whitespaceValue_throwsParseExceptionWithConstraintMessage() {
+        assertThrows(ParseException.class, Phone.MESSAGE_CONSTRAINTS, () -> ParserUtil.parsePhone("   "));
+    }
+
+    @Test
+    public void parsePhone_nonBlankInvalidValue_throwsParseExceptionWithFormattedMessage() {
         assertThrows(ParseException.class,
-            Phone.MESSAGE_CONSTRAINTS, () -> ParserUtil.parsePhone("   "));
+            String.format(Phone.MESSAGE_INVALID_PHONE, "abc"), () -> ParserUtil.parsePhone("abc"));
     }
 }


### PR DESCRIPTION
## Summary
This PR fixes the phone validation message shown when the phone field is left blank.

## Problem
Issue #137 reported that leaving the phone field blank can surface the raw placeholder:
`Invalid Number: The number %1$s is not valid`

## Fix
- Replaced the phone constraint message with a normal generic validation message
- Added a regression test to verify blank and whitespace-only phone input no longer leaks the placeholder

Closes #137