### PR TITLE
Make 'grpadd' fail atomically

### DIFF
--- a/src/main/java/hitlist/logic/commands/AddGroupCommand.java
+++ b/src/main/java/hitlist/logic/commands/AddGroupCommand.java
@@ -65,8 +65,6 @@ public class AddGroupCommand extends Command {
             throw new CommandException(String.format(MESSAGE_DUPLICATE_GROUP, toAdd.getName()));
         }
 
-        model.addGroup(toAdd);
-
         for (Name memberName : memberNames) {
             Person member = model.getHitList().getPersonList().stream()
                 .filter(person -> person.getName().equals(memberName))
@@ -75,6 +73,8 @@ public class AddGroupCommand extends Command {
 
             toAdd.addMember(member);
         }
+
+        model.addGroup(toAdd);
 
         return new CommandResult(String.format(MESSAGE_SUCCESS, toAdd.getName()), SHOW_GROUP_LIST);
     }


### PR DESCRIPTION
Only call model.addGroup() when all supplied member names are found in HitList

Fixes #155 