### PR TITLE
Fix `delete /n NAME` command

### DIFF
--- a/src/main/java/hitlist/logic/commands/DeleteCommand.java
+++ b/src/main/java/hitlist/logic/commands/DeleteCommand.java
@@ -75,8 +75,8 @@ public class DeleteCommand extends Command {
     }
 
     private CommandResult executeByName(Model model) throws CommandException {
-        List<Person> lastShownList = model.getFilteredPersonList();
-        Person personToDelete = lastShownList.stream()
+        List<Person> nameMatches = model.getPersonsByName(targetName);
+        Person personToDelete = nameMatches.stream()
                 .filter(person -> person.getName().equals(targetName))
                 .findFirst()
                 .orElseThrow(() -> new CommandException(String.format(Messages.MESSAGE_PERSON_NOT_FOUND, targetName)));


### PR DESCRIPTION
Fixes #172 

This PR lets the DeleteCommand use a non-filtered person list when searching for the Person object to delete.

- Use `Model::getPersonsByName` to query for Person objects instead of `Model::getFilteredPersonList`