### PR TITLE
Use contact name as primary identifier

### DIFF
--- a/src/main/java/hitlist/model/person/Person.java
+++ b/src/main/java/hitlist/model/person/Person.java
@@ -58,7 +58,7 @@ public class Person {
         }
 
         return otherPerson != null
-                && otherPerson.getPhone().equals(getPhone());
+                && otherPerson.getName().equals(getName());
     }
 
     /**

--- a/src/test/java/hitlist/model/person/PersonTest.java
+++ b/src/test/java/hitlist/model/person/PersonTest.java
@@ -26,23 +26,23 @@ public class PersonTest {
         // null -> returns false
         assertFalse(ALICE.isSamePerson(null));
 
-        // same name, all other attributes different -> returns false
+        // same name, all other attributes different -> returns true
         Person editedAlice = new PersonBuilder(ALICE).withPhone(VALID_PHONE_BOB).withEmail(VALID_EMAIL_BOB)
                 .withAddress(VALID_ADDRESS_BOB).build();
-        assertFalse(ALICE.isSamePerson(editedAlice));
-
-        // different name, all other attributes same -> returns true
-        editedAlice = new PersonBuilder(ALICE).withName(VALID_NAME_BOB).build();
         assertTrue(ALICE.isSamePerson(editedAlice));
+
+        // different name, all other attributes same -> returns false
+        editedAlice = new PersonBuilder(ALICE).withName(VALID_NAME_BOB).build();
+        assertFalse(ALICE.isSamePerson(editedAlice));
 
         // name differs in case, all other attributes same -> returns true
         Person editedBob = new PersonBuilder(BOB).withName(VALID_NAME_BOB.toLowerCase()).build();
         assertTrue(BOB.isSamePerson(editedBob));
 
-        // name has trailing spaces, all other attributes same -> returns true
+        // name has trailing spaces, all other attributes same -> returns false
         String nameWithTrailingSpaces = VALID_NAME_BOB + " ";
         editedBob = new PersonBuilder(BOB).withName(nameWithTrailingSpaces).build();
-        assertTrue(BOB.isSamePerson(editedBob));
+        assertFalse(BOB.isSamePerson(editedBob));
     }
 
     @Test


### PR DESCRIPTION
Fixes #178 
Fixes #173 by disallowing duplicate contacts with same name

This PR makes HitList treat the contact's name as the primary identifier of a contact.

# Existing Behaviour

Currently, HitList only treats contacts as the same iff. they share the same phone number. This is a sensible option since you would not expect two contacts to share the same number.

# Rationale

Most commands in HitList use `/n NAME` to reference a candidate contact.

Pragmatically, we also have email and address fields for each contact. Therefore, the user can use those to disambiguate two contacts.