### PR TITLE
Add text wrapping to descriptions

### DIFF
--- a/src/main/resources/view/CompanyListCard.fxml
+++ b/src/main/resources/view/CompanyListCard.fxml
@@ -27,7 +27,7 @@
         </Label>
         <Label fx:id="name" text="\$first" styleClass="cell_big_label" />
       </HBox>
-      <Label fx:id="description" styleClass="cell_small_label" text="\$description" />
+      <Label fx:id="description" styleClass="cell_small_label" text="\$description" wrapText="true" />
 
       <HBox fx:id="rolesWrapper" spacing="5" alignment="CENTER_LEFT">
         <padding>

--- a/src/main/resources/view/RoleListCard.fxml
+++ b/src/main/resources/view/RoleListCard.fxml
@@ -26,7 +26,7 @@
         </Label>
         <Label fx:id="name" text="\$first" styleClass="cell_big_label" />
       </HBox>
-      <Label fx:id="description" styleClass="cell_small_label" text="\$description" />
+      <Label fx:id="description" styleClass="cell_small_label" text="\$description" wrapText="true" />
     </VBox>
   </GridPane>
 </HBox>


### PR DESCRIPTION
Fixes #287 
Fixes #274 

<img width="1277" height="339" alt="image" src="https://github.com/user-attachments/assets/9ea5574d-75d4-491c-a739-0969ffa87e76" />

<img width="1298" height="366" alt="image" src="https://github.com/user-attachments/assets/7927c0ef-42e7-4078-b158-018afb76be48" />
