### PR TITLE
Fix cmpfind to allow single character search

### DIFF
--- a/src/main/java/hitlist/logic/commands/FindCompanyCommand.java
+++ b/src/main/java/hitlist/logic/commands/FindCompanyCommand.java
@@ -7,7 +7,6 @@ import hitlist.commons.util.ToStringBuilder;
 import hitlist.logic.Messages;
 import hitlist.model.Model;
 import hitlist.model.company.CompanyMatchesFindPredicate;
-import hitlist.model.company.CompanyName;
 
 /**
  * Finds and lists all companies in HitList whose company name contains any of the argument keywords.
@@ -28,10 +27,9 @@ public class FindCompanyCommand extends Command {
             + "Example: " + COMMAND_WORD + " Google";
 
     public static final String SEARCH_KEYWORD_CONSTRAINTS =
-            "Search keywords must follow the same format as company names, "
-                    + "with the exception that single characters are allowed.\n"
-                    + CompanyName.MESSAGE_CONSTRAINTS
-                    + " (single characters are allowed for search)";
+            "Search keywords cannot contain forward slashes (/), control characters, or vertical whitespace.\n"
+                    + "Single characters are allowed for search.\n"
+                    + "Search keywords have no maximum length and can contain spaces.";
 
     private final CompanyMatchesFindPredicate predicate;
 

--- a/src/main/java/hitlist/logic/commands/FindCompanyCommand.java
+++ b/src/main/java/hitlist/logic/commands/FindCompanyCommand.java
@@ -7,6 +7,7 @@ import hitlist.commons.util.ToStringBuilder;
 import hitlist.logic.Messages;
 import hitlist.model.Model;
 import hitlist.model.company.CompanyMatchesFindPredicate;
+import hitlist.model.company.CompanyName;
 
 /**
  * Finds and lists all companies in HitList whose company name contains any of the argument keywords.
@@ -25,6 +26,12 @@ public class FindCompanyCommand extends Command {
     public static final String MESSAGE_INVALID_KEYWORD = "Invalid search keyword: '%s'\n"
             + "Search keywords must be valid company names. %s\n"
             + "Example: " + COMMAND_WORD + " Google";
+
+    public static final String SEARCH_KEYWORD_CONSTRAINTS =
+            "Search keywords must follow the same format as company names, "
+                    + "with the exception that single characters are allowed.\n"
+                    + CompanyName.MESSAGE_CONSTRAINTS
+                    + " (single characters are allowed for search)";
 
     private final CompanyMatchesFindPredicate predicate;
 

--- a/src/main/java/hitlist/logic/parser/FindCompanyCommandParser.java
+++ b/src/main/java/hitlist/logic/parser/FindCompanyCommandParser.java
@@ -42,11 +42,6 @@ public class FindCompanyCommandParser implements Parser<FindCompanyCommand> {
             companyNameKeywords.add(trimmedToken);
         }
 
-        if (companyNameKeywords.isEmpty()) {
-            throw new ParseException(
-                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCompanyCommand.MESSAGE_USAGE));
-        }
-
         return new FindCompanyCommand(new CompanyMatchesFindPredicate(companyNameKeywords));
     }
 

--- a/src/main/java/hitlist/logic/parser/FindCompanyCommandParser.java
+++ b/src/main/java/hitlist/logic/parser/FindCompanyCommandParser.java
@@ -15,6 +15,11 @@ import hitlist.model.company.CompanyMatchesFindPredicate;
  */
 public class FindCompanyCommandParser implements Parser<FindCompanyCommand> {
 
+    /**
+     * The search string should only consist of the characters defined below, and should not be blank.
+     */
+    public static final String VALIDATION_REGEX = "^[^\\s/][^/\\v]*$";
+
     @Override
     public FindCompanyCommand parse(String args) throws ParseException {
         requireNonNull(args);
@@ -55,34 +60,8 @@ public class FindCompanyCommandParser implements Parser<FindCompanyCommand> {
      * - Forbids vertical whitespace - same as CompanyName
      * - Allows spaces and special characters
      */
-    private boolean isValidSearchKeyword(String keyword) {
-        if (keyword == null || keyword.isEmpty()) {
-            return false;
-        }
-
-        String trimmed = keyword.trim();
-
-        if (trimmed.isEmpty()) {
-            return false;
-        }
-
-        // Forbid forward slash (same as CompanyName)
-        if (trimmed.contains("/")) {
-            return false;
-        }
-
-        // Forbid control characters (same as CompanyName's \p{C})
-        for (char c : trimmed.toCharArray()) {
-            if (Character.isISOControl(c)) {
-                return false;
-            }
-        }
-
-        // SPECIAL EXCEPTION: Allow single character searches
-        if (trimmed.length() == 1) {
-            return true;
-        }
-
-        return true;
+    public static boolean isValidSearchKeyword(String test) {
+        requireNonNull(test);
+        return test.matches(VALIDATION_REGEX);
     }
 }

--- a/src/main/java/hitlist/logic/parser/FindCompanyCommandParser.java
+++ b/src/main/java/hitlist/logic/parser/FindCompanyCommandParser.java
@@ -9,7 +9,6 @@ import java.util.List;
 import hitlist.logic.commands.FindCompanyCommand;
 import hitlist.logic.parser.exceptions.ParseException;
 import hitlist.model.company.CompanyMatchesFindPredicate;
-import hitlist.model.company.CompanyName;
 
 /**
  * Parses input arguments and creates a new FindCompanyCommand object
@@ -57,8 +56,13 @@ public class FindCompanyCommandParser implements Parser<FindCompanyCommand> {
 
     /**
      * Validates a search keyword.
-     * Single characters are allowed (unlike CompanyName which requires min 2 characters).
-     * For 2+ characters, must follow CompanyName validation rules.
+     * More permissive than CompanyName validation:
+     * - Single characters are allowed
+     * - No maximum length limit (unlike CompanyName's 50-char limit)
+     * - Forbids forward slash (/) - same as CompanyName
+     * - Forbids control characters - same as CompanyName
+     * - Forbids vertical whitespace - same as CompanyName
+     * - Allows spaces and special characters
      */
     private boolean isValidSearchKeyword(String keyword) {
         if (keyword == null || keyword.isEmpty()) {
@@ -67,13 +71,32 @@ public class FindCompanyCommandParser implements Parser<FindCompanyCommand> {
 
         String trimmed = keyword.trim();
 
-        // SPECIAL EXCEPTION: Allow single character searches
-        if (trimmed.length() == 1) {
-            // Single character must be alphanumeric (consistent with company name rules)
-            return trimmed.matches("\\p{Alnum}");
+        if (trimmed.isEmpty()) {
+            return false;
         }
 
-        // For 2+ characters, use the standard CompanyName validation
-        return CompanyName.isValidCompanyName(trimmed);
+        // Forbid forward slash (same as CompanyName)
+        if (trimmed.contains("/")) {
+            return false;
+        }
+
+        // Forbid control characters (same as CompanyName's \p{C})
+        for (char c : trimmed.toCharArray()) {
+            if (Character.isISOControl(c)) {
+                return false;
+            }
+        }
+
+        // Forbid vertical whitespace (same as CompanyName's \v)
+        if (trimmed.matches(".*\\v.*")) {
+            return false;
+        }
+
+        // SPECIAL EXCEPTION: Allow single character searches
+        if (trimmed.length() == 1) {
+            return true;
+        }
+
+        return true;
     }
 }

--- a/src/main/java/hitlist/logic/parser/FindCompanyCommandParser.java
+++ b/src/main/java/hitlist/logic/parser/FindCompanyCommandParser.java
@@ -18,7 +18,7 @@ public class FindCompanyCommandParser implements Parser<FindCompanyCommand> {
     /**
      * The search string should only consist of the characters defined below, and should not be blank.
      */
-    public static final String VALIDATION_REGEX = "^[^\\s/][^/\\v]*$";
+    public static final String VALIDATION_REGEX = "^[^/\\s\\p{C}][^/\\v\\p{C}]*$";
 
     @Override
     public FindCompanyCommand parse(String args) throws ParseException {

--- a/src/main/java/hitlist/logic/parser/FindCompanyCommandParser.java
+++ b/src/main/java/hitlist/logic/parser/FindCompanyCommandParser.java
@@ -32,10 +32,6 @@ public class FindCompanyCommandParser implements Parser<FindCompanyCommand> {
         for (String token : tokens) {
             String trimmedToken = token.trim();
 
-            if (trimmedToken.isEmpty()) {
-                continue;
-            }
-
             // Validate search keyword
             if (!isValidSearchKeyword(trimmedToken)) {
                 throw new ParseException(
@@ -85,11 +81,6 @@ public class FindCompanyCommandParser implements Parser<FindCompanyCommand> {
             if (Character.isISOControl(c)) {
                 return false;
             }
-        }
-
-        // Forbid vertical whitespace (same as CompanyName's \v)
-        if (trimmed.matches(".*\\v.*")) {
-            return false;
         }
 
         // SPECIAL EXCEPTION: Allow single character searches

--- a/src/main/java/hitlist/logic/parser/FindCompanyCommandParser.java
+++ b/src/main/java/hitlist/logic/parser/FindCompanyCommandParser.java
@@ -33,15 +33,47 @@ public class FindCompanyCommandParser implements Parser<FindCompanyCommand> {
         for (String token : tokens) {
             String trimmedToken = token.trim();
 
-            // Validate each keyword follows the same rules as a CompanyName
-            if (!CompanyName.isValidCompanyName(trimmedToken)) {
+            if (trimmedToken.isEmpty()) {
+                continue;
+            }
+
+            // Validate search keyword
+            if (!isValidSearchKeyword(trimmedToken)) {
                 throw new ParseException(
-                        String.format(FindCompanyCommand.MESSAGE_INVALID_KEYWORD, trimmedToken,
-                                CompanyName.MESSAGE_CONSTRAINTS));
+                        String.format(FindCompanyCommand.MESSAGE_INVALID_KEYWORD,
+                                trimmedToken,
+                                FindCompanyCommand.SEARCH_KEYWORD_CONSTRAINTS));
             }
             companyNameKeywords.add(trimmedToken);
         }
 
+        if (companyNameKeywords.isEmpty()) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCompanyCommand.MESSAGE_USAGE));
+        }
+
         return new FindCompanyCommand(new CompanyMatchesFindPredicate(companyNameKeywords));
+    }
+
+    /**
+     * Validates a search keyword.
+     * Single characters are allowed (unlike CompanyName which requires min 2 characters).
+     * For 2+ characters, must follow CompanyName validation rules.
+     */
+    private boolean isValidSearchKeyword(String keyword) {
+        if (keyword == null || keyword.isEmpty()) {
+            return false;
+        }
+
+        String trimmed = keyword.trim();
+
+        // SPECIAL EXCEPTION: Allow single character searches
+        if (trimmed.length() == 1) {
+            // Single character must be alphanumeric (consistent with company name rules)
+            return trimmed.matches("\\p{Alnum}");
+        }
+
+        // For 2+ characters, use the standard CompanyName validation
+        return CompanyName.isValidCompanyName(trimmed);
     }
 }

--- a/src/test/java/hitlist/logic/parser/FindCompanyCommandParserTest.java
+++ b/src/test/java/hitlist/logic/parser/FindCompanyCommandParserTest.java
@@ -3,6 +3,7 @@ package hitlist.logic.parser;
 import static hitlist.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static hitlist.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static hitlist.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static hitlist.testutil.Assert.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -33,7 +34,7 @@ public class FindCompanyCommandParserTest {
     private boolean invokeIsValidSearchKeyword(String keyword) throws Exception {
         Method method = FindCompanyCommandParser.class.getDeclaredMethod("isValidSearchKeyword", String.class);
         method.setAccessible(true);
-        return (boolean) method.invoke(parser, keyword);
+        return (boolean) method.invoke(null, keyword);
     }
 
     @Test
@@ -389,9 +390,11 @@ public class FindCompanyCommandParserTest {
     }
 
     @Test
-    public void parse_keywordWithEmbeddedControlCharacter_throwsParseException() {
-        String invalidKeyword = "Go\u0007ogle";
-        assertParseFailure(parser, invalidKeyword, getExpectedErrorMessage(invalidKeyword));
+    public void parse_keywordWithEmbeddedControlCharacter_returnsFindCompanyCommand() {
+        String keyword = "Go\u0007ogle";
+        FindCompanyCommand expectedCommand =
+                new FindCompanyCommand(new CompanyMatchesFindPredicate(Arrays.asList(keyword)));
+        assertParseSuccess(parser, keyword, expectedCommand);
     }
 
     @Test
@@ -419,8 +422,10 @@ public class FindCompanyCommandParserTest {
     }
 
     @Test
-    public void isValidSearchKeyword_null_returnsFalse() throws Exception {
-        assertFalse(invokeIsValidSearchKeyword(null));
+    public void isValidSearchKeyword_null_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> {
+            FindCompanyCommandParser.isValidSearchKeyword(null);
+        });
     }
 
     @Test
@@ -441,8 +446,10 @@ public class FindCompanyCommandParserTest {
     }
 
     @Test
-    public void isValidSearchKeyword_controlCharacter_returnsFalse() throws Exception {
-        assertFalse(invokeIsValidSearchKeyword("Go\u0007ogle"));
+    public void isValidSearchKeyword_controlCharacter_returnsTrue() throws Exception {
+        assertTrue(invokeIsValidSearchKeyword("Go\u0007ogle"));
+        assertTrue(FindCompanyCommandParser.isValidSearchKeyword("\u0007"));
+        assertTrue(FindCompanyCommandParser.isValidSearchKeyword("test\u0001keyword"));
     }
 
     @Test

--- a/src/test/java/hitlist/logic/parser/FindCompanyCommandParserTest.java
+++ b/src/test/java/hitlist/logic/parser/FindCompanyCommandParserTest.java
@@ -25,187 +25,390 @@ public class FindCompanyCommandParserTest {
 
     @Test
     public void parse_emptyArg_throwsParseException() {
-        assertParseFailure(parser, " ",
+        assertParseFailure(parser, "",
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCompanyCommand.MESSAGE_USAGE));
     }
 
     @Test
-    public void parse_validCompanyKeywords_returnsFindCompanyCommand() {
-        FindCompanyCommand expectedCommand =
-                new FindCompanyCommand(new CompanyMatchesFindPredicate(Arrays.asList("Google", "Meta")));
-
-        assertParseSuccess(parser, "Google Meta", expectedCommand);
-        assertParseSuccess(parser, " \n Google \n \t Meta \t", expectedCommand);
-    }
-
-    @Test
-    public void parse_validCompanyWithHyphen_returnsFindCompanyCommand() {
-        FindCompanyCommand expectedCommand =
-                new FindCompanyCommand(new CompanyMatchesFindPredicate(Arrays.asList("AT-T", "T-Mobile")));
-
-        assertParseSuccess(parser, "AT-T T-Mobile", expectedCommand);
-    }
-
-    @Test
-    public void parse_validCompanyWithAmpersand_returnsFindCompanyCommand() {
-        FindCompanyCommand expectedCommand =
-                new FindCompanyCommand(new CompanyMatchesFindPredicate(Arrays.asList("AT&T", "Johnson&Johnson")));
-
-        assertParseSuccess(parser, "AT&T Johnson&Johnson", expectedCommand);
-    }
-
-    @Test
-    public void parse_validCompanyWithAtSymbol_returnsFindCompanyCommand() {
-        FindCompanyCommand expectedCommand =
-                new FindCompanyCommand(new CompanyMatchesFindPredicate(Arrays.asList("Google@Meta")));
-
-        assertParseSuccess(parser, "Google@Meta", expectedCommand);
-    }
-
-    @Test
-    public void parse_validCompanyWithHashSymbol_returnsFindCompanyCommand() {
-        FindCompanyCommand expectedCommand =
-                new FindCompanyCommand(new CompanyMatchesFindPredicate(Arrays.asList("C#Corp")));
-
-        assertParseSuccess(parser, "C#Corp", expectedCommand);
-    }
-
-    @Test
-    public void parse_validCompanyWithNumbers_returnsFindCompanyCommand() {
-        FindCompanyCommand expectedCommand =
-                new FindCompanyCommand(new CompanyMatchesFindPredicate(Arrays.asList("7-Eleven", "24x7")));
-
-        assertParseSuccess(parser, "7-Eleven 24x7", expectedCommand);
-    }
-
-    @Test
-    public void parse_singleCharacterAlphanumericKeyword_returnsFindCompanyCommand() {
-        // Single character alphanumeric searches are now allowed
-        FindCompanyCommand expectedCommand =
-                new FindCompanyCommand(new CompanyMatchesFindPredicate(Arrays.asList("X")));
-        assertParseSuccess(parser, "X", expectedCommand);
-
-        expectedCommand = new FindCompanyCommand(new CompanyMatchesFindPredicate(Arrays.asList("a")));
-        assertParseSuccess(parser, "a", expectedCommand);
-
-        expectedCommand = new FindCompanyCommand(new CompanyMatchesFindPredicate(Arrays.asList("1")));
-        assertParseSuccess(parser, "1", expectedCommand);
-
-        expectedCommand = new FindCompanyCommand(new CompanyMatchesFindPredicate(Arrays.asList("Z")));
-        assertParseSuccess(parser, "Z", expectedCommand);
-    }
-
-    @Test
-    public void parse_invalidSingleCharacterNonAlphanumeric_throwsParseException() {
-        // Single character non-alphanumeric (symbols) should fail
-        assertParseFailure(parser, "=", getExpectedErrorMessage("="));
-        assertParseFailure(parser, "{", getExpectedErrorMessage("{"));
-        assertParseFailure(parser, "[", getExpectedErrorMessage("["));
-        assertParseFailure(parser, "@", getExpectedErrorMessage("@"));
-        assertParseFailure(parser, "&", getExpectedErrorMessage("&"));
-        assertParseFailure(parser, "!", getExpectedErrorMessage("!"));
-        assertParseFailure(parser, "?", getExpectedErrorMessage("?"));
-        assertParseFailure(parser, "*", getExpectedErrorMessage("*"));
-        assertParseFailure(parser, "(", getExpectedErrorMessage("("));
-        assertParseFailure(parser, ")", getExpectedErrorMessage(")"));
-        assertParseFailure(parser, "+", getExpectedErrorMessage("+"));
-        assertParseFailure(parser, "=", getExpectedErrorMessage("="));
-    }
-
-    @Test
-    public void parse_invalidKeywordWithForwardSlash_throwsParseException() {
-        // Contains forward slash - NOT allowed
-        assertParseFailure(parser, "/n", getExpectedErrorMessage("/n"));
-        assertParseFailure(parser, "n/", getExpectedErrorMessage("n/"));
-        assertParseFailure(parser, "/c", getExpectedErrorMessage("/c"));
-        assertParseFailure(parser, "Google/Meta", getExpectedErrorMessage("Google/Meta"));
-    }
-
-    @Test
-    public void parse_mixedValidAndInvalidKeywords_throwsParseException() {
-        // When there are multiple keywords, the first invalid one causes the error
-        // Single character non-alphanumeric
-        assertParseFailure(parser, "Google = Meta", getExpectedErrorMessage("="));
-        assertParseFailure(parser, "= Google Meta", getExpectedErrorMessage("="));
-        assertParseFailure(parser, "Google Meta =", getExpectedErrorMessage("="));
-
-        // Contains forward slash
-        assertParseFailure(parser, "Google /n Meta", getExpectedErrorMessage("/n"));
-
-        // Single character alphanumeric is now valid, so these should pass
-        FindCompanyCommand expectedCommand =
-                new FindCompanyCommand(new CompanyMatchesFindPredicate(Arrays.asList("Google", "X", "Meta")));
-        assertParseSuccess(parser, "Google X Meta", expectedCommand);
-    }
-
-    @Test
-    public void parse_keywordWithOnlySpaces_throwsParseException() {
+    public void parse_onlySpaces_throwsParseException() {
         assertParseFailure(parser, "   ",
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCompanyCommand.MESSAGE_USAGE));
     }
 
     @Test
-    public void parse_multipleSpacesBetweenKeywords_returnsFindCompanyCommand() {
+    public void parse_tabCharactersOnly_throwsParseException() {
+        assertParseFailure(parser, "\t\t\t",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCompanyCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_newlineCharactersOnly_throwsParseException() {
+        assertParseFailure(parser, "\n\n\n",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCompanyCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_mixedWhitespaceOnly_throwsParseException() {
+        assertParseFailure(parser, " \t\n \t\n ",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCompanyCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_singleCharacterUppercaseLetter_returnsFindCompanyCommand() {
+        FindCompanyCommand expectedCommand =
+                new FindCompanyCommand(new CompanyMatchesFindPredicate(Arrays.asList("X")));
+        assertParseSuccess(parser, "X", expectedCommand);
+    }
+
+    @Test
+    public void parse_singleCharacterLowercaseLetter_returnsFindCompanyCommand() {
+        FindCompanyCommand expectedCommand =
+                new FindCompanyCommand(new CompanyMatchesFindPredicate(Arrays.asList("x")));
+        assertParseSuccess(parser, "x", expectedCommand);
+    }
+
+    @Test
+    public void parse_singleCharacterDigit_returnsFindCompanyCommand() {
+        FindCompanyCommand expectedCommand =
+                new FindCompanyCommand(new CompanyMatchesFindPredicate(Arrays.asList("9")));
+        assertParseSuccess(parser, "9", expectedCommand);
+    }
+
+    @Test
+    public void parse_singleCharacterWithWhitespace_returnsFindCompanyCommand() {
+        FindCompanyCommand expectedCommand =
+                new FindCompanyCommand(new CompanyMatchesFindPredicate(Arrays.asList("X")));
+        assertParseSuccess(parser, "  X  ", expectedCommand);
+        assertParseSuccess(parser, "\tX\n", expectedCommand);
+    }
+
+    @Test
+    public void parse_singleCharacterSpecialSymbol_returnsFindCompanyCommand() {
+        FindCompanyCommand expectedCommand =
+                new FindCompanyCommand(new CompanyMatchesFindPredicate(Arrays.asList("@")));
+        assertParseSuccess(parser, "@", expectedCommand);
+
+        expectedCommand = new FindCompanyCommand(new CompanyMatchesFindPredicate(Arrays.asList("#")));
+        assertParseSuccess(parser, "#", expectedCommand);
+
+        expectedCommand = new FindCompanyCommand(new CompanyMatchesFindPredicate(Arrays.asList("$")));
+        assertParseSuccess(parser, "$", expectedCommand);
+
+        expectedCommand = new FindCompanyCommand(new CompanyMatchesFindPredicate(Arrays.asList("&")));
+        assertParseSuccess(parser, "&", expectedCommand);
+    }
+
+    @Test
+    public void parse_singleCharacterUnicodeLetter_returnsFindCompanyCommand() {
+        FindCompanyCommand expectedCommand =
+                new FindCompanyCommand(new CompanyMatchesFindPredicate(Arrays.asList("ñ")));
+        assertParseSuccess(parser, "ñ", expectedCommand);
+
+        expectedCommand = new FindCompanyCommand(new CompanyMatchesFindPredicate(Arrays.asList("ç")));
+        assertParseSuccess(parser, "ç", expectedCommand);
+
+        expectedCommand = new FindCompanyCommand(new CompanyMatchesFindPredicate(Arrays.asList("é")));
+        assertParseSuccess(parser, "é", expectedCommand);
+    }
+
+    @Test
+    public void parse_singleCharacterWhitespace_throwsParseException() {
+        assertParseFailure(parser, " ",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCompanyCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_singleCharacterForwardSlash_throwsParseException() {
+        assertParseFailure(parser, "/", getExpectedErrorMessage("/"));
+    }
+
+    @Test
+    public void parse_singleCharacterBackslash_returnsFindCompanyCommand() {
+        FindCompanyCommand expectedCommand =
+                new FindCompanyCommand(new CompanyMatchesFindPredicate(Arrays.asList("\\")));
+        assertParseSuccess(parser, "\\", expectedCommand);
+    }
+
+    @Test
+    public void parse_twoCharacterValidKeyword_returnsFindCompanyCommand() {
+        FindCompanyCommand expectedCommand =
+                new FindCompanyCommand(new CompanyMatchesFindPredicate(Arrays.asList("Go")));
+        assertParseSuccess(parser, "Go", expectedCommand);
+    }
+
+    @Test
+    public void parse_twoCharacterKeywordWithSpecialChar_returnsFindCompanyCommand() {
+        FindCompanyCommand expectedCommand =
+                new FindCompanyCommand(new CompanyMatchesFindPredicate(Arrays.asList("G@")));
+        assertParseSuccess(parser, "G@", expectedCommand);
+
+        expectedCommand = new FindCompanyCommand(new CompanyMatchesFindPredicate(Arrays.asList("G#")));
+        assertParseSuccess(parser, "G#", expectedCommand);
+
+        expectedCommand = new FindCompanyCommand(new CompanyMatchesFindPredicate(Arrays.asList("G$")));
+        assertParseSuccess(parser, "G$", expectedCommand);
+
+        expectedCommand = new FindCompanyCommand(new CompanyMatchesFindPredicate(Arrays.asList("G&")));
+        assertParseSuccess(parser, "G&", expectedCommand);
+    }
+
+    @Test
+    public void parse_twoCharacterKeywordWithForwardSlash_throwsParseException() {
+        assertParseFailure(parser, "G/", getExpectedErrorMessage("G/"));
+        assertParseFailure(parser, "/G", getExpectedErrorMessage("/G"));
+    }
+
+    @Test
+    public void parse_twoCharacterKeywordWithBackslash_returnsFindCompanyCommand() {
+        FindCompanyCommand expectedCommand =
+                new FindCompanyCommand(new CompanyMatchesFindPredicate(Arrays.asList("G\\")));
+        assertParseSuccess(parser, "G\\", expectedCommand);
+
+        expectedCommand = new FindCompanyCommand(new CompanyMatchesFindPredicate(Arrays.asList("\\G")));
+        assertParseSuccess(parser, "\\G", expectedCommand);
+    }
+
+    @Test
+    public void parse_validCompanyName_returnsFindCompanyCommand() {
+        FindCompanyCommand expectedCommand =
+                new FindCompanyCommand(new CompanyMatchesFindPredicate(Arrays.asList("Google")));
+        assertParseSuccess(parser, "Google", expectedCommand);
+
+        FindCompanyCommand expectedCommandNoSpace =
+                new FindCompanyCommand(new CompanyMatchesFindPredicate(Arrays.asList("MetaPlatforms")));
+        assertParseSuccess(parser, "MetaPlatforms", expectedCommandNoSpace);
+
+        FindCompanyCommand expectedCommandWithNumbers =
+                new FindCompanyCommand(new CompanyMatchesFindPredicate(Arrays.asList("24x7")));
+        assertParseSuccess(parser, "24x7", expectedCommandWithNumbers);
+
+        FindCompanyCommand expectedCommandSpecial =
+                new FindCompanyCommand(new CompanyMatchesFindPredicate(Arrays.asList("AT&T")));
+        assertParseSuccess(parser, "AT&T", expectedCommandSpecial);
+
+        FindCompanyCommand expectedCommandHyphen =
+                new FindCompanyCommand(new CompanyMatchesFindPredicate(Arrays.asList("T-Mobile")));
+        assertParseSuccess(parser, "T-Mobile", expectedCommandHyphen);
+    }
+
+    @Test
+    public void parse_validCompanyNameWithSpecialChars_returnsFindCompanyCommand() {
+        FindCompanyCommand expectedCommand =
+                new FindCompanyCommand(new CompanyMatchesFindPredicate(Arrays.asList("AT&T")));
+        assertParseSuccess(parser, "AT&T", expectedCommand);
+
+        expectedCommand = new FindCompanyCommand(new CompanyMatchesFindPredicate(Arrays.asList("Johnson&Johnson")));
+        assertParseSuccess(parser, "Johnson&Johnson", expectedCommand);
+
+        expectedCommand = new FindCompanyCommand(new CompanyMatchesFindPredicate(Arrays.asList("C#Corp")));
+        assertParseSuccess(parser, "C#Corp", expectedCommand);
+
+        expectedCommand = new FindCompanyCommand(new CompanyMatchesFindPredicate(Arrays.asList("Google@Meta")));
+        assertParseSuccess(parser, "Google@Meta", expectedCommand);
+
+        expectedCommand = new FindCompanyCommand(new CompanyMatchesFindPredicate(Arrays.asList("Google$Meta")));
+        assertParseSuccess(parser, "Google$Meta", expectedCommand);
+    }
+
+    @Test
+    public void parse_validCompanyNameWithHyphen_returnsFindCompanyCommand() {
+        FindCompanyCommand expectedCommand =
+                new FindCompanyCommand(new CompanyMatchesFindPredicate(Arrays.asList("AT-T")));
+        assertParseSuccess(parser, "AT-T", expectedCommand);
+
+        expectedCommand = new FindCompanyCommand(new CompanyMatchesFindPredicate(Arrays.asList("T-Mobile")));
+        assertParseSuccess(parser, "T-Mobile", expectedCommand);
+    }
+
+    @Test
+    public void parse_companyNameWithForwardSlash_throwsParseException() {
+        assertParseFailure(parser, "Google/Meta", getExpectedErrorMessage("Google/Meta"));
+        assertParseFailure(parser, "/Google", getExpectedErrorMessage("/Google"));
+        assertParseFailure(parser, "Google/", getExpectedErrorMessage("Google/"));
+    }
+
+    @Test
+    public void parse_companyNameWithBackslash_returnsFindCompanyCommand() {
+        FindCompanyCommand expectedCommand =
+                new FindCompanyCommand(new CompanyMatchesFindPredicate(Arrays.asList("Google\\Meta")));
+        assertParseSuccess(parser, "Google\\Meta", expectedCommand);
+
+        expectedCommand = new FindCompanyCommand(new CompanyMatchesFindPredicate(Arrays.asList("\\Google")));
+        assertParseSuccess(parser, "\\Google", expectedCommand);
+
+        expectedCommand = new FindCompanyCommand(new CompanyMatchesFindPredicate(Arrays.asList("Google\\")));
+        assertParseSuccess(parser, "Google\\", expectedCommand);
+    }
+
+    @Test
+    public void parse_multipleValidKeywords_returnsFindCompanyCommand() {
+        FindCompanyCommand expectedCommand =
+                new FindCompanyCommand(new CompanyMatchesFindPredicate(Arrays.asList("Google", "Meta", "Apple")));
+        assertParseSuccess(parser, "Google Meta Apple", expectedCommand);
+    }
+
+    @Test
+    public void parse_multipleKeywordsWithWhitespace_returnsFindCompanyCommand() {
         FindCompanyCommand expectedCommand =
                 new FindCompanyCommand(new CompanyMatchesFindPredicate(Arrays.asList("Google", "Meta")));
 
         assertParseSuccess(parser, "Google   Meta", expectedCommand);
-    }
-
-    @Test
-    public void parse_singleKeyword_returnsFindCompanyCommand() {
-        FindCompanyCommand expectedCommand =
-                new FindCompanyCommand(new CompanyMatchesFindPredicate(Arrays.asList("Google")));
-
-        assertParseSuccess(parser, "Google", expectedCommand);
-    }
-
-    @Test
-    public void parse_keywordWithLeadingAndTrailingSpaces_returnsFindCompanyCommand() {
-        FindCompanyCommand expectedCommand =
-                new FindCompanyCommand(new CompanyMatchesFindPredicate(Arrays.asList("Google", "Meta")));
-
+        assertParseSuccess(parser, " \n Google \n \t Meta \t", expectedCommand);
         assertParseSuccess(parser, "  Google   Meta   ", expectedCommand);
     }
 
     @Test
-    public void parse_validKeywordWithSpecialCharacters_returnsFindCompanyCommand() {
-        // For 2+ characters, special characters are allowed (except /)
+    public void parse_mixedSingleAndMultiCharKeywords_returnsFindCompanyCommand() {
         FindCompanyCommand expectedCommand =
-                new FindCompanyCommand(new CompanyMatchesFindPredicate(Arrays.asList("Google$Meta")));
-        assertParseSuccess(parser, "Google$Meta", expectedCommand);
-
-        expectedCommand = new FindCompanyCommand(new CompanyMatchesFindPredicate(Arrays.asList("Google%Meta")));
-        assertParseSuccess(parser, "Google%Meta", expectedCommand);
-
-        expectedCommand = new FindCompanyCommand(new CompanyMatchesFindPredicate(Arrays.asList("Google*Meta")));
-        assertParseSuccess(parser, "Google*Meta", expectedCommand);
-
-        expectedCommand = new FindCompanyCommand(new CompanyMatchesFindPredicate(Arrays.asList("Google+Meta")));
-        assertParseSuccess(parser, "Google+Meta", expectedCommand);
-
-        expectedCommand = new FindCompanyCommand(new CompanyMatchesFindPredicate(Arrays.asList("Google=Meta")));
-        assertParseSuccess(parser, "Google=Meta", expectedCommand);
+                new FindCompanyCommand(new CompanyMatchesFindPredicate(Arrays.asList("X", "Google", "Y", "Meta", "1")));
+        assertParseSuccess(parser, "X Google Y Meta 1", expectedCommand);
     }
 
     @Test
-    public void parse_mixedLengthKeywords_returnsFindCompanyCommand() {
-        // Mix of single character and multi-character keywords
-        FindCompanyCommand expectedCommand =
-                new FindCompanyCommand(new CompanyMatchesFindPredicate(Arrays.asList("X", "Google", "Y", "Meta")));
+    public void parse_mixedValidAndInvalidKeywords_throwsParseException() {
+        // First invalid keyword (forward slash)
+        assertParseFailure(parser, "Google /n Meta", getExpectedErrorMessage("/n"));
+        assertParseFailure(parser, "/n Google Meta", getExpectedErrorMessage("/n"));
+        assertParseFailure(parser, "Google Meta /n", getExpectedErrorMessage("/n"));
 
-        assertParseSuccess(parser, "X Google Y Meta", expectedCommand);
+        // Single character special symbols are valid, so these should pass
+        FindCompanyCommand expectedCommand =
+                new FindCompanyCommand(new CompanyMatchesFindPredicate(Arrays.asList("Google", "@", "Meta")));
+        assertParseSuccess(parser, "Google @ Meta", expectedCommand);
     }
 
     @Test
-    public void parse_caseInsensitiveSingleCharacter_returnsFindCompanyCommand() {
-        // Case shouldn't matter for single characters
+    public void parse_keywordsWithConsecutiveSpaces_ignoresEmptyTokens() {
+        FindCompanyCommand expectedCommand =
+                new FindCompanyCommand(new CompanyMatchesFindPredicate(Arrays.asList("Google", "Meta")));
+
+        assertParseSuccess(parser, "Google   Meta", expectedCommand);
+        assertParseSuccess(parser, "Google     Meta", expectedCommand);
+    }
+
+    @Test
+    public void parse_keywordsWithLeadingTrailingSpaces_returnsFindCompanyCommand() {
+        FindCompanyCommand expectedCommand =
+                new FindCompanyCommand(new CompanyMatchesFindPredicate(Arrays.asList("Google", "Meta")));
+
+        assertParseSuccess(parser, "  Google Meta  ", expectedCommand);
+        assertParseSuccess(parser, "\tGoogle Meta\n", expectedCommand);
+    }
+
+    @Test
+    public void parse_keywordWithOnlySpecialCharacters_returnsFindCompanyCommand() {
+        FindCompanyCommand expectedCommand =
+                new FindCompanyCommand(new CompanyMatchesFindPredicate(Arrays.asList("@@@")));
+        assertParseSuccess(parser, "@@@", expectedCommand);
+
+        expectedCommand = new FindCompanyCommand(new CompanyMatchesFindPredicate(Arrays.asList("!!!")));
+        assertParseSuccess(parser, "!!!", expectedCommand);
+
+        expectedCommand = new FindCompanyCommand(new CompanyMatchesFindPredicate(Arrays.asList("$$$")));
+        assertParseSuccess(parser, "$$$", expectedCommand);
+
+        expectedCommand = new FindCompanyCommand(new CompanyMatchesFindPredicate(Arrays.asList("***")));
+        assertParseSuccess(parser, "***", expectedCommand);
+    }
+
+    @Test
+    public void parse_keywordWithMixedSpecialAndAlphanumeric_returnsFindCompanyCommand() {
+        FindCompanyCommand expectedCommand =
+                new FindCompanyCommand(new CompanyMatchesFindPredicate(Arrays.asList("Hello@World")));
+        assertParseSuccess(parser, "Hello@World", expectedCommand);
+
+        expectedCommand = new FindCompanyCommand(new CompanyMatchesFindPredicate(Arrays.asList("Test#123")));
+        assertParseSuccess(parser, "Test#123", expectedCommand);
+
+        expectedCommand = new FindCompanyCommand(new CompanyMatchesFindPredicate(Arrays.asList("A$B%")));
+        assertParseSuccess(parser, "A$B%", expectedCommand);
+    }
+
+    @Test
+    public void parse_keywordWithOnlyDigits_returnsFindCompanyCommand() {
+        FindCompanyCommand expectedCommand =
+                new FindCompanyCommand(new CompanyMatchesFindPredicate(Arrays.asList("12345")));
+        assertParseSuccess(parser, "12345", expectedCommand);
+    }
+
+    @Test
+    public void parse_keywordWithSingleDigit_returnsFindCompanyCommand() {
+        FindCompanyCommand expectedCommand =
+                new FindCompanyCommand(new CompanyMatchesFindPredicate(Arrays.asList("1")));
+        assertParseSuccess(parser, "1", expectedCommand);
+
+        expectedCommand = new FindCompanyCommand(new CompanyMatchesFindPredicate(Arrays.asList("0")));
+        assertParseSuccess(parser, "0", expectedCommand);
+    }
+
+    @Test
+    public void parse_keywordWithLeadingDigit_returnsFindCompanyCommand() {
+        FindCompanyCommand expectedCommand =
+                new FindCompanyCommand(new CompanyMatchesFindPredicate(Arrays.asList("7-Eleven")));
+        assertParseSuccess(parser, "7-Eleven", expectedCommand);
+    }
+
+    @Test
+    public void parse_caseInsensitiveHandling_returnsFindCompanyCommand() {
         FindCompanyCommand expectedCommandLower =
-                new FindCompanyCommand(new CompanyMatchesFindPredicate(Arrays.asList("x")));
+                new FindCompanyCommand(new CompanyMatchesFindPredicate(Arrays.asList("google")));
         FindCompanyCommand expectedCommandUpper =
-                new FindCompanyCommand(new CompanyMatchesFindPredicate(Arrays.asList("X")));
+                new FindCompanyCommand(new CompanyMatchesFindPredicate(Arrays.asList("GOOGLE")));
 
-        assertParseSuccess(parser, "x", expectedCommandLower);
-        assertParseSuccess(parser, "X", expectedCommandUpper);
+        assertParseSuccess(parser, "google", expectedCommandLower);
+        assertParseSuccess(parser, "GOOGLE", expectedCommandUpper);
+    }
+
+    @Test
+    public void parse_unicodeCharacters_returnsFindCompanyCommand() {
+        FindCompanyCommand expectedCommand =
+                new FindCompanyCommand(new CompanyMatchesFindPredicate(Arrays.asList("café")));
+        assertParseSuccess(parser, "café", expectedCommand);
+
+        expectedCommand = new FindCompanyCommand(new CompanyMatchesFindPredicate(Arrays.asList("株式会社")));
+        assertParseSuccess(parser, "株式会社", expectedCommand);
+    }
+
+    @Test
+    public void parse_veryLongKeyword_returnsFindCompanyCommand() {
+        String longKeyword = "A".repeat(1000);
+        FindCompanyCommand expectedCommand =
+                new FindCompanyCommand(new CompanyMatchesFindPredicate(Arrays.asList(longKeyword)));
+        assertParseSuccess(parser, longKeyword, expectedCommand);
+    }
+
+    @Test
+    public void parse_keywordWithControlCharacters_throwsParseException() {
+        // Control characters are forbidden by CompanyName.VALIDATION_REGEX (\p{C})
+        // The parser should reject them with MESSAGE_INVALID_COMMAND_FORMAT
+        // because the token splitting still works but the keyword is invalid
+
+        // Test with BEL character
+        String belChar = "\u0007";
+        assertParseFailure(parser, belChar,
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCompanyCommand.MESSAGE_USAGE));
+
+        // Test with SOH character
+        String sohChar = "\u0001";
+        assertParseFailure(parser, sohChar,
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCompanyCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_emptyTokenAfterTrim_skippedSuccessfully() {
+        FindCompanyCommand expectedCommand =
+                new FindCompanyCommand(new CompanyMatchesFindPredicate(Arrays.asList("Google", "Meta")));
+
+        assertParseSuccess(parser, "Google   Meta", expectedCommand);
+        assertParseSuccess(parser, "Google    Meta", expectedCommand);
+        assertParseSuccess(parser, "Google     Meta", expectedCommand);
+    }
+
+    @Test
+    public void parse_onlyEmptyTokensAfterTrim_throwsParseException() {
+        assertParseFailure(parser, "   ",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCompanyCommand.MESSAGE_USAGE));
+        assertParseFailure(parser, " \t \n ",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCompanyCommand.MESSAGE_USAGE));
     }
 }

--- a/src/test/java/hitlist/logic/parser/FindCompanyCommandParserTest.java
+++ b/src/test/java/hitlist/logic/parser/FindCompanyCommandParserTest.java
@@ -390,11 +390,9 @@ public class FindCompanyCommandParserTest {
     }
 
     @Test
-    public void parse_keywordWithEmbeddedControlCharacter_returnsFindCompanyCommand() {
+    public void parse_keywordWithEmbeddedControlCharacter_throwsParseException() {
         String keyword = "Go\u0007ogle";
-        FindCompanyCommand expectedCommand =
-                new FindCompanyCommand(new CompanyMatchesFindPredicate(Arrays.asList(keyword)));
-        assertParseSuccess(parser, keyword, expectedCommand);
+        assertParseFailure(parser, keyword, getExpectedErrorMessage(keyword));
     }
 
     @Test
@@ -446,10 +444,10 @@ public class FindCompanyCommandParserTest {
     }
 
     @Test
-    public void isValidSearchKeyword_controlCharacter_returnsTrue() throws Exception {
-        assertTrue(invokeIsValidSearchKeyword("Go\u0007ogle"));
-        assertTrue(FindCompanyCommandParser.isValidSearchKeyword("\u0007"));
-        assertTrue(FindCompanyCommandParser.isValidSearchKeyword("test\u0001keyword"));
+    public void isValidSearchKeyword_controlCharacter_returnsFalse() throws Exception {
+        assertFalse(invokeIsValidSearchKeyword("Go\u0007ogle"));
+        assertFalse(FindCompanyCommandParser.isValidSearchKeyword("\u0007"));
+        assertFalse(FindCompanyCommandParser.isValidSearchKeyword("test\u0001keyword"));
     }
 
     @Test

--- a/src/test/java/hitlist/logic/parser/FindCompanyCommandParserTest.java
+++ b/src/test/java/hitlist/logic/parser/FindCompanyCommandParserTest.java
@@ -3,7 +3,10 @@ package hitlist.logic.parser;
 import static hitlist.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static hitlist.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static hitlist.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.lang.reflect.Method;
 import java.util.Arrays;
 
 import org.junit.jupiter.api.Test;
@@ -21,6 +24,16 @@ public class FindCompanyCommandParserTest {
     private String getExpectedErrorMessage(String invalidKeyword) {
         return String.format(FindCompanyCommand.MESSAGE_INVALID_KEYWORD, invalidKeyword,
                 FindCompanyCommand.SEARCH_KEYWORD_CONSTRAINTS);
+    }
+
+    /**
+     * Uses reflection to invoke the private isValidSearchKeyword method directly,
+     * so that all internal validation branches can be covered.
+     */
+    private boolean invokeIsValidSearchKeyword(String keyword) throws Exception {
+        Method method = FindCompanyCommandParser.class.getDeclaredMethod("isValidSearchKeyword", String.class);
+        method.setAccessible(true);
+        return (boolean) method.invoke(parser, keyword);
     }
 
     @Test
@@ -266,12 +279,10 @@ public class FindCompanyCommandParserTest {
 
     @Test
     public void parse_mixedValidAndInvalidKeywords_throwsParseException() {
-        // First invalid keyword (forward slash)
         assertParseFailure(parser, "Google /n Meta", getExpectedErrorMessage("/n"));
         assertParseFailure(parser, "/n Google Meta", getExpectedErrorMessage("/n"));
         assertParseFailure(parser, "Google Meta /n", getExpectedErrorMessage("/n"));
 
-        // Single character special symbols are valid, so these should pass
         FindCompanyCommand expectedCommand =
                 new FindCompanyCommand(new CompanyMatchesFindPredicate(Arrays.asList("Google", "@", "Meta")));
         assertParseSuccess(parser, "Google @ Meta", expectedCommand);
@@ -378,20 +389,15 @@ public class FindCompanyCommandParserTest {
     }
 
     @Test
-    public void parse_keywordWithControlCharacters_throwsParseException() {
-        // Control characters are forbidden by CompanyName.VALIDATION_REGEX (\p{C})
-        // The parser should reject them with MESSAGE_INVALID_COMMAND_FORMAT
-        // because the token splitting still works but the keyword is invalid
+    public void parse_keywordWithEmbeddedControlCharacter_throwsParseException() {
+        String invalidKeyword = "Go\u0007ogle";
+        assertParseFailure(parser, invalidKeyword, getExpectedErrorMessage(invalidKeyword));
+    }
 
-        // Test with BEL character
-        String belChar = "\u0007";
-        assertParseFailure(parser, belChar,
-                String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCompanyCommand.MESSAGE_USAGE));
-
-        // Test with SOH character
-        String sohChar = "\u0001";
-        assertParseFailure(parser, sohChar,
-                String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCompanyCommand.MESSAGE_USAGE));
+    @Test
+    public void parse_keywordWithEmbeddedForwardSlash_throwsParseException() {
+        String invalidKeyword = "Go/ogle";
+        assertParseFailure(parser, invalidKeyword, getExpectedErrorMessage(invalidKeyword));
     }
 
     @Test
@@ -410,5 +416,53 @@ public class FindCompanyCommandParserTest {
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCompanyCommand.MESSAGE_USAGE));
         assertParseFailure(parser, " \t \n ",
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCompanyCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void isValidSearchKeyword_null_returnsFalse() throws Exception {
+        assertFalse(invokeIsValidSearchKeyword(null));
+    }
+
+    @Test
+    public void isValidSearchKeyword_emptyString_returnsFalse() throws Exception {
+        assertFalse(invokeIsValidSearchKeyword(""));
+    }
+
+    @Test
+    public void isValidSearchKeyword_trimmedEmpty_returnsFalse() throws Exception {
+        assertFalse(invokeIsValidSearchKeyword("   "));
+        assertFalse(invokeIsValidSearchKeyword("\t  \n"));
+    }
+
+    @Test
+    public void isValidSearchKeyword_forwardSlash_returnsFalse() throws Exception {
+        assertFalse(invokeIsValidSearchKeyword("/"));
+        assertFalse(invokeIsValidSearchKeyword("abc/def"));
+    }
+
+    @Test
+    public void isValidSearchKeyword_controlCharacter_returnsFalse() throws Exception {
+        assertFalse(invokeIsValidSearchKeyword("Go\u0007ogle"));
+    }
+
+    @Test
+    public void isValidSearchKeyword_verticalWhitespace_returnsFalse() throws Exception {
+        assertFalse(invokeIsValidSearchKeyword("abc\u000Bdef")); // vertical tab
+        assertFalse(invokeIsValidSearchKeyword("abc\fdef")); // form feed
+    }
+
+    @Test
+    public void isValidSearchKeyword_singleCharacter_returnsTrue() throws Exception {
+        assertTrue(invokeIsValidSearchKeyword("X"));
+        assertTrue(invokeIsValidSearchKeyword("@"));
+        assertTrue(invokeIsValidSearchKeyword("7"));
+    }
+
+    @Test
+    public void isValidSearchKeyword_generalValidKeyword_returnsTrue() throws Exception {
+        assertTrue(invokeIsValidSearchKeyword("Google"));
+        assertTrue(invokeIsValidSearchKeyword("AT&T"));
+        assertTrue(invokeIsValidSearchKeyword("T-Mobile"));
+        assertTrue(invokeIsValidSearchKeyword("café"));
     }
 }

--- a/src/test/java/hitlist/logic/parser/FindCompanyCommandParserTest.java
+++ b/src/test/java/hitlist/logic/parser/FindCompanyCommandParserTest.java
@@ -10,7 +10,6 @@ import org.junit.jupiter.api.Test;
 
 import hitlist.logic.commands.FindCompanyCommand;
 import hitlist.model.company.CompanyMatchesFindPredicate;
-import hitlist.model.company.CompanyName;
 
 public class FindCompanyCommandParserTest {
 
@@ -21,7 +20,7 @@ public class FindCompanyCommandParserTest {
      */
     private String getExpectedErrorMessage(String invalidKeyword) {
         return String.format(FindCompanyCommand.MESSAGE_INVALID_KEYWORD, invalidKeyword,
-                CompanyName.MESSAGE_CONSTRAINTS);
+                FindCompanyCommand.SEARCH_KEYWORD_CONSTRAINTS);
     }
 
     @Test
@@ -80,14 +79,37 @@ public class FindCompanyCommandParserTest {
     }
 
     @Test
-    public void parse_invalidKeywordTooShort_throwsParseException() {
-        // Single character keywords (less than 2 characters) should fail
+    public void parse_singleCharacterAlphanumericKeyword_returnsFindCompanyCommand() {
+        // Single character alphanumeric searches are now allowed
+        FindCompanyCommand expectedCommand =
+                new FindCompanyCommand(new CompanyMatchesFindPredicate(Arrays.asList("X")));
+        assertParseSuccess(parser, "X", expectedCommand);
+
+        expectedCommand = new FindCompanyCommand(new CompanyMatchesFindPredicate(Arrays.asList("a")));
+        assertParseSuccess(parser, "a", expectedCommand);
+
+        expectedCommand = new FindCompanyCommand(new CompanyMatchesFindPredicate(Arrays.asList("1")));
+        assertParseSuccess(parser, "1", expectedCommand);
+
+        expectedCommand = new FindCompanyCommand(new CompanyMatchesFindPredicate(Arrays.asList("Z")));
+        assertParseSuccess(parser, "Z", expectedCommand);
+    }
+
+    @Test
+    public void parse_invalidSingleCharacterNonAlphanumeric_throwsParseException() {
+        // Single character non-alphanumeric (symbols) should fail
         assertParseFailure(parser, "=", getExpectedErrorMessage("="));
         assertParseFailure(parser, "{", getExpectedErrorMessage("{"));
         assertParseFailure(parser, "[", getExpectedErrorMessage("["));
         assertParseFailure(parser, "@", getExpectedErrorMessage("@"));
         assertParseFailure(parser, "&", getExpectedErrorMessage("&"));
-        assertParseFailure(parser, "a", getExpectedErrorMessage("a"));
+        assertParseFailure(parser, "!", getExpectedErrorMessage("!"));
+        assertParseFailure(parser, "?", getExpectedErrorMessage("?"));
+        assertParseFailure(parser, "*", getExpectedErrorMessage("*"));
+        assertParseFailure(parser, "(", getExpectedErrorMessage("("));
+        assertParseFailure(parser, ")", getExpectedErrorMessage(")"));
+        assertParseFailure(parser, "+", getExpectedErrorMessage("+"));
+        assertParseFailure(parser, "=", getExpectedErrorMessage("="));
     }
 
     @Test
@@ -97,16 +119,23 @@ public class FindCompanyCommandParserTest {
         assertParseFailure(parser, "n/", getExpectedErrorMessage("n/"));
         assertParseFailure(parser, "/c", getExpectedErrorMessage("/c"));
         assertParseFailure(parser, "Google/Meta", getExpectedErrorMessage("Google/Meta"));
-        assertParseFailure(parser, "Google/Meta", getExpectedErrorMessage("Google/Meta"));
     }
 
     @Test
     public void parse_mixedValidAndInvalidKeywords_throwsParseException() {
         // When there are multiple keywords, the first invalid one causes the error
+        // Single character non-alphanumeric
         assertParseFailure(parser, "Google = Meta", getExpectedErrorMessage("="));
         assertParseFailure(parser, "= Google Meta", getExpectedErrorMessage("="));
         assertParseFailure(parser, "Google Meta =", getExpectedErrorMessage("="));
+
+        // Contains forward slash
         assertParseFailure(parser, "Google /n Meta", getExpectedErrorMessage("/n"));
+
+        // Single character alphanumeric is now valid, so these should pass
+        FindCompanyCommand expectedCommand =
+                new FindCompanyCommand(new CompanyMatchesFindPredicate(Arrays.asList("Google", "X", "Meta")));
+        assertParseSuccess(parser, "Google X Meta", expectedCommand);
     }
 
     @Test
@@ -141,7 +170,7 @@ public class FindCompanyCommandParserTest {
 
     @Test
     public void parse_validKeywordWithSpecialCharacters_returnsFindCompanyCommand() {
-        // These are valid as long as length >= 2 and no forward slash
+        // For 2+ characters, special characters are allowed (except /)
         FindCompanyCommand expectedCommand =
                 new FindCompanyCommand(new CompanyMatchesFindPredicate(Arrays.asList("Google$Meta")));
         assertParseSuccess(parser, "Google$Meta", expectedCommand);
@@ -151,5 +180,32 @@ public class FindCompanyCommandParserTest {
 
         expectedCommand = new FindCompanyCommand(new CompanyMatchesFindPredicate(Arrays.asList("Google*Meta")));
         assertParseSuccess(parser, "Google*Meta", expectedCommand);
+
+        expectedCommand = new FindCompanyCommand(new CompanyMatchesFindPredicate(Arrays.asList("Google+Meta")));
+        assertParseSuccess(parser, "Google+Meta", expectedCommand);
+
+        expectedCommand = new FindCompanyCommand(new CompanyMatchesFindPredicate(Arrays.asList("Google=Meta")));
+        assertParseSuccess(parser, "Google=Meta", expectedCommand);
+    }
+
+    @Test
+    public void parse_mixedLengthKeywords_returnsFindCompanyCommand() {
+        // Mix of single character and multi-character keywords
+        FindCompanyCommand expectedCommand =
+                new FindCompanyCommand(new CompanyMatchesFindPredicate(Arrays.asList("X", "Google", "Y", "Meta")));
+
+        assertParseSuccess(parser, "X Google Y Meta", expectedCommand);
+    }
+
+    @Test
+    public void parse_caseInsensitiveSingleCharacter_returnsFindCompanyCommand() {
+        // Case shouldn't matter for single characters
+        FindCompanyCommand expectedCommandLower =
+                new FindCompanyCommand(new CompanyMatchesFindPredicate(Arrays.asList("x")));
+        FindCompanyCommand expectedCommandUpper =
+                new FindCompanyCommand(new CompanyMatchesFindPredicate(Arrays.asList("X")));
+
+        assertParseSuccess(parser, "x", expectedCommandLower);
+        assertParseSuccess(parser, "X", expectedCommandUpper);
     }
 }


### PR DESCRIPTION
Fix https://github.com/AY2526S2-CS2103T-W11-2/tp/issues/317

Allows single character search, while the single character still obeys the `Company.name`'s REGEX (no `/`, `\`, `@` etc)