### PR TITLE
Fix GroupAdd DG execution order

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -719,7 +719,7 @@ Step 4. The `HitListParser` calls the `parse(" /g Students /n Alex Yeoh /n Berni
 
 Step 5. The `AddGroupCommand` is returned to the `LogicManager`, and the `AddGroupCommandParser` is subsequently destroyed.
 
-Step 6. `LogicManager` calls `AddGroupCommand#execute()`. This command calls `Model#addGroup(toAdd)` to add the group to the internal HitList state, and then resolves each provided member name against existing contacts before adding the matched `Person` objects to the group.
+Step 6. `LogicManager` calls `AddGroupCommand#execute()`. The command first resolves each provided member name against existing contacts and adds the matched `Person` objects to the group. After all members are successfully resolved, it calls `Model#addGroup(toAdd)` to add the fully populated group to the internal HitList state.
 
 <div class="text-center">
   <puml src="diagrams/add-group/GroupAddExecution.puml" alt="GroupAdd-Execution" />

--- a/docs/diagrams/add-group/GroupAddActivityDiagram.puml
+++ b/docs/diagrams/add-group/GroupAddActivityDiagram.puml
@@ -1,28 +1,35 @@
 @startuml
+
 skinparam ActivityFontSize 15
 skinparam ArrowFontSize 12
 
 start
+
 :User executes command;
 
 if () then ([Command is valid])
   :Parse group name and optional member names;
   :Create new Group object;
+
   if () then ([Group does not exist in HitList])
-    :Add Group to Model;
+
     if () then ([All provided members exist])
       :Add resolved members to Group;
+      :Add Group to Model;
       :Save updated HitList to Storage;
       :Display success message to User;
     else ([A member cannot be found])
       :Display contact not found error;
     endif
+
   else ([Group already exists])
     :Display duplicate group error;
   endif
+
 else ([Command is invalid])
   :Display invalid command format error;
 endif
 
 stop
+
 @enduml

--- a/docs/diagrams/add-group/GroupAddSequenceDiagram-Logic.puml
+++ b/docs/diagrams/add-group/GroupAddSequenceDiagram-Logic.puml
@@ -1,5 +1,6 @@
 @startuml
 !include ../style.puml
+
 skinparam ArrowFontStyle plain
 
 box Logic LOGIC_COLOR_T1
@@ -15,12 +16,14 @@ end box
 
 [-> LogicManager : execute("grpadd /g Students /n Alex Yeoh /n Bernice Yu")
 activate LogicManager
+
 LogicManager -> HitListParser : parseCommand("grpadd /g Students /n Alex Yeoh /n Bernice Yu")
 activate HitListParser
 
 create AddGroupCommandParser
 HitListParser -> AddGroupCommandParser
 activate AddGroupCommandParser
+
 AddGroupCommandParser --> HitListParser
 deactivate AddGroupCommandParser
 
@@ -30,11 +33,13 @@ activate AddGroupCommandParser
 create AddGroupCommand
 AddGroupCommandParser -> AddGroupCommand
 activate AddGroupCommand
+
 AddGroupCommand --> AddGroupCommandParser : c
 deactivate AddGroupCommand
 
 AddGroupCommandParser --> HitListParser : c
 deactivate AddGroupCommandParser
+
 AddGroupCommandParser -[hidden]-> HitListParser
 destroy AddGroupCommandParser
 
@@ -43,10 +48,6 @@ deactivate HitListParser
 
 LogicManager -> AddGroupCommand : execute()
 activate AddGroupCommand
-AddGroupCommand -> Model : addGroup(toAdd)
-activate Model
-Model --> AddGroupCommand
-deactivate Model
 
 loop for each member name
   AddGroupCommand -> Model : getHitList()
@@ -55,11 +56,18 @@ loop for each member name
   deactivate Model
 end
 
+AddGroupCommand -> Model : addGroup(toAdd)
+activate Model
+Model --> AddGroupCommand
+deactivate Model
+
 AddGroupCommand --> LogicManager : result
 deactivate AddGroupCommand
+
 AddGroupCommand -[hidden]-> LogicManager
 destroy AddGroupCommand
 
 [<--LogicManager
 deactivate LogicManager
+
 @enduml


### PR DESCRIPTION
Fixes #282

This PR fixes a documentation mismatch in the AddGroup Developer Guide.

Changes made:
- corrected AddGroup Step 6 in `DeveloperGuide.md`
- updated `GroupAddSequenceDiagram-Logic.puml` so `addGroup(toAdd)` happens after member resolution
- updated `GroupAddActivityDiagram.puml` so the group is added to the model only after members are resolved