### PR TITLE
Fix delete parser to reject index and name together

### DIFF
--- a/src/main/java/hitlist/logic/parser/DeleteCommandParser.java
+++ b/src/main/java/hitlist/logic/parser/DeleteCommandParser.java
@@ -18,27 +18,31 @@ public class DeleteCommandParser implements Parser<DeleteCommand> {
     /**
      * Parses the given {@code String} of arguments in the context of the DeleteCommand
      * and returns a DeleteCommand object for execution.
+     *
      * @throws ParseException if the user input does not conform the expected format
      */
     public DeleteCommand parse(String args) throws ParseException {
         ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_NAME);
+
         String preamble = argMultimap.getPreamble().trim();
         Optional<String> nameValue = argMultimap.getValue(PREFIX_NAME);
 
         try {
-            if (!preamble.isEmpty()) {
-                Index index = ParserUtil.parseIndex(preamble);
-                return new DeleteCommand(index);
-            } else {
-                // Preamble is not a valid index, treat as name
-                Name name = ParserUtil.parseName(nameValue.orElseThrow(() -> new ParseException(
-                        String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE))));
+            if (nameValue.isPresent() && preamble.isEmpty()) {
+                Name name = ParserUtil.parseName(nameValue.get());
                 return new DeleteCommand(name);
             }
+
+            if (nameValue.isEmpty() && !preamble.isEmpty()) {
+                Index index = ParserUtil.parseIndex(preamble);
+                return new DeleteCommand(index);
+            }
+
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
         } catch (ParseException pe) {
             throw new ParseException(
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE), pe);
         }
     }
-
 }

--- a/src/test/java/hitlist/logic/parser/DeleteCommandParserTest.java
+++ b/src/test/java/hitlist/logic/parser/DeleteCommandParserTest.java
@@ -27,7 +27,7 @@ public class DeleteCommandParserTest {
         assertParseSuccess(parser, "1", new DeleteCommand(INDEX_FIRST_PERSON));
     }
 
-     @Test
+    @Test
     public void parse_validNameArgs_returnsDeleteCommand() {
         assertParseSuccess(parser, PREFIX_NAME + " Alice Pauline",
                 new DeleteCommand(new Name("Alice Pauline")));

--- a/src/test/java/hitlist/logic/parser/DeleteCommandParserTest.java
+++ b/src/test/java/hitlist/logic/parser/DeleteCommandParserTest.java
@@ -1,6 +1,7 @@
 package hitlist.logic.parser;
 
 import static hitlist.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static hitlist.logic.parser.CliSyntax.PREFIX_NAME;
 import static hitlist.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static hitlist.logic.parser.CommandParserTestUtil.assertParseSuccess;
 import static hitlist.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
@@ -8,6 +9,7 @@ import static hitlist.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 import org.junit.jupiter.api.Test;
 
 import hitlist.logic.commands.DeleteCommand;
+import hitlist.model.person.Name;
 
 /**
  * As we are only doing white-box testing, our test cases do not cover path variations
@@ -18,15 +20,24 @@ import hitlist.logic.commands.DeleteCommand;
  */
 public class DeleteCommandParserTest {
 
-    private DeleteCommandParser parser = new DeleteCommandParser();
+    private final DeleteCommandParser parser = new DeleteCommandParser();
 
     @Test
-    public void parse_validArgs_returnsDeleteCommand() {
+    public void parse_validIndexArgs_returnsDeleteCommand() {
         assertParseSuccess(parser, "1", new DeleteCommand(INDEX_FIRST_PERSON));
     }
 
     @Test
+    public void parse_validNameArgs_returnsDeleteCommand() {
+        assertParseSuccess(parser, PREFIX_NAME + " Alice Pauline",
+                new DeleteCommand(new Name("Alice Pauline")));
+    }
+
+    @Test
     public void parse_invalidArgs_throwsParseException() {
-        assertParseFailure(parser, "a", String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
+        assertParseFailure(parser, "a",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
+        assertParseFailure(parser, "1 " + PREFIX_NAME + " NonExistentName",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
     }
 }

--- a/src/test/java/hitlist/logic/parser/DeleteCommandParserTest.java
+++ b/src/test/java/hitlist/logic/parser/DeleteCommandParserTest.java
@@ -27,7 +27,7 @@ public class DeleteCommandParserTest {
         assertParseSuccess(parser, "1", new DeleteCommand(INDEX_FIRST_PERSON));
     }
 
-    @Test
+     @Test
     public void parse_validNameArgs_returnsDeleteCommand() {
         assertParseSuccess(parser, PREFIX_NAME + " Alice Pauline",
                 new DeleteCommand(new Name("Alice Pauline")));
@@ -38,6 +38,8 @@ public class DeleteCommandParserTest {
         assertParseFailure(parser, "a",
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
         assertParseFailure(parser, "1 " + PREFIX_NAME + " NonExistentName",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
+        assertParseFailure(parser, "123 " + PREFIX_NAME,
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
     }
 }


### PR DESCRIPTION
Fixes #247

## Summary
- reject delete commands that provide both an index and /n
- preserve valid index-only delete parsing
- preserve valid name-only delete parsing
- add parser coverage for the combined-input bug

## Testing
- .\gradlew.bat test --tests "hitlist.logic.parser.DeleteCommandParserTest"
- .\gradlew.bat test