### PR TITLE
Fix case-insensitive name deduplication for grpadd

### DIFF
--- a/src/main/java/hitlist/model/person/Name.java
+++ b/src/main/java/hitlist/model/person/Name.java
@@ -13,7 +13,7 @@ public class Name {
 
     public static final String MESSAGE_CONSTRAINTS =
             "Names should only contain alphabetic characters, dashes,"
-                    + " apostrophes, and spaces, and it should not be blank";
+             + " apostrophes, and spaces, and it should not be blank";
 
     /*
      * Names should only contain alphabetic characters, spaces, -, and ', and it should not be blank

--- a/src/main/java/hitlist/model/person/Name.java
+++ b/src/main/java/hitlist/model/person/Name.java
@@ -13,7 +13,7 @@ public class Name {
 
     public static final String MESSAGE_CONSTRAINTS =
             "Names should only contain alphabetic characters, dashes,"
-             + " apostrophes, and spaces, and it should not be blank";
+            + " apostrophes, and spaces, and it should not be blank";
 
     /*
      * Names should only contain alphabetic characters, spaces, -, and ', and it should not be blank

--- a/src/main/java/hitlist/model/person/Name.java
+++ b/src/main/java/hitlist/model/person/Name.java
@@ -3,6 +3,8 @@ package hitlist.model.person;
 import static hitlist.commons.util.AppUtil.checkArgument;
 import static java.util.Objects.requireNonNull;
 
+import java.util.Locale;
+
 /**
  * Represents a Person's name in the HitList.
  * Guarantees: immutable; is valid as declared in {@link #isValidName(String)}
@@ -11,7 +13,7 @@ public class Name {
 
     public static final String MESSAGE_CONSTRAINTS =
             "Names should only contain alphabetic characters, dashes,"
-            + " apostrophes, and spaces, and it should not be blank";
+                    + " apostrophes, and spaces, and it should not be blank";
 
     /*
      * Names should only contain alphabetic characters, spaces, -, and ', and it should not be blank
@@ -38,7 +40,6 @@ public class Name {
         return test.matches(VALIDATION_REGEX);
     }
 
-
     @Override
     public String toString() {
         return fullName;
@@ -61,7 +62,6 @@ public class Name {
 
     @Override
     public int hashCode() {
-        return fullName.hashCode();
+        return fullName.toLowerCase(Locale.ROOT).hashCode();
     }
-
 }

--- a/src/test/java/hitlist/logic/parser/AssignGroupCommandParserTest.java
+++ b/src/test/java/hitlist/logic/parser/AssignGroupCommandParserTest.java
@@ -51,9 +51,10 @@ public class AssignGroupCommandParserTest {
     @Test
     public void parse_compulsoryFieldMissing_failure() {
         String expectedMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT, AssignGroupCommand.MESSAGE_USAGE);
-
         assertParseFailure(parser, NAME_DESC_AMY, expectedMessage);
+
         assertParseFailure(parser, GROUP_NAME_DESC_STUDENTS, expectedMessage);
+
         assertParseFailure(parser, VALID_NAME_AMY + " " + VALID_GROUP_NAME_STUDENTS, expectedMessage);
     }
 
@@ -62,7 +63,6 @@ public class AssignGroupCommandParserTest {
         assertParseFailure(parser, INVALID_NAME_DESC + GROUP_NAME_DESC_STUDENTS, Name.MESSAGE_CONSTRAINTS);
 
         assertParseFailure(parser, NAME_DESC_AMY + INVALID_GROUP_NAME_DESC, GroupName.MESSAGE_CONSTRAINTS);
-
         assertParseFailure(parser, PREAMBLE_NON_EMPTY + NAME_DESC_AMY + GROUP_NAME_DESC_STUDENTS,
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, AssignGroupCommand.MESSAGE_USAGE));
     }

--- a/src/test/java/hitlist/model/person/NameTest.java
+++ b/src/test/java/hitlist/model/person/NameTest.java
@@ -1,6 +1,7 @@
 package hitlist.model.person;
 
 import static hitlist.testutil.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -47,6 +48,9 @@ public class NameTest {
         // same values -> returns true
         assertTrue(name.equals(new Name("Valid Name")));
 
+        // same values, different casing -> returns true
+        assertTrue(name.equals(new Name("valid name")));
+
         // same object -> returns true
         assertTrue(name.equals(name));
 
@@ -58,5 +62,13 @@ public class NameTest {
 
         // different values -> returns false
         assertFalse(name.equals(new Name("Other Valid Name")));
+    }
+
+    @Test
+    public void hashCode_sameNameDifferentCasing_sameHashCode() {
+        Name firstName = new Name("Alice");
+        Name secondName = new Name("alice");
+
+        assertEquals(firstName.hashCode(), secondName.hashCode());
     }
 }


### PR DESCRIPTION
Fixes #265

## Summary

* fix `Name.hashCode()` so it is consistent with case-insensitive `Name.equals()`
* add regression tests for case-insensitive equality and hash code behavior
* restore correct deduplication of repeated member names such as `/n Alice /n alice` during `grpadd`

## Root cause

`grpadd` parses member names into a `Set<Name>`.
`Name.equals()` already compares names case-insensitively, but `Name.hashCode()` previously used the original casing.
That violated the `equals`/`hashCode` contract and allowed hash-based collections to treat `Alice` and `alice` as different entries.

## Testing

* `./gradlew test`
* `./gradlew check coverage`
* manual test: `grpadd /g Team /n Alice /n alice`