### PR TITLE
Fix edit validation for same name and same contact

### DIFF
--- a/src/main/java/hitlist/logic/commands/AddCommand.java
+++ b/src/main/java/hitlist/logic/commands/AddCommand.java
@@ -35,6 +35,8 @@ public class AddCommand extends Command {
     public static final String MESSAGE_SUCCESS = "Added %1$s with contact number %2$s";
     public static final String MESSAGE_DUPLICATE_NAME = "Duplicate Contact: "
             + "A contact with the name '%s' already exists";
+    public static final String MESSAGE_DUPLICATE_PHONE = "Duplicate Phone number: "
+            + "A contact with the number '%s' already exists";
 
     private final Person toAdd;
 
@@ -58,6 +60,17 @@ public class AddCommand extends Command {
         if (existingWithSameName.isPresent()) {
             throw new CommandException(String.format(
                     MESSAGE_DUPLICATE_NAME,
+                    toAdd.getName()));
+        }
+
+        // Find existing person with same number
+        Optional<Person> existingWithNumber = model.getFilteredPersonList().stream()
+                .filter(p -> p.getPhone().equals(toAdd.getPhone()))
+                .findFirst();
+
+        if (existingWithNumber.isPresent()) {
+            throw new CommandException(String.format(
+                    MESSAGE_DUPLICATE_PHONE,
                     toAdd.getName()));
         }
 

--- a/src/main/java/hitlist/logic/commands/AddCommand.java
+++ b/src/main/java/hitlist/logic/commands/AddCommand.java
@@ -6,6 +6,8 @@ import static hitlist.logic.parser.CliSyntax.PREFIX_NAME;
 import static hitlist.logic.parser.CliSyntax.PREFIX_PHONE;
 import static java.util.Objects.requireNonNull;
 
+import java.util.Optional;
+
 import hitlist.commons.util.ToStringBuilder;
 import hitlist.logic.commands.exceptions.CommandException;
 import hitlist.model.Model;

--- a/src/main/java/hitlist/logic/commands/AddCommand.java
+++ b/src/main/java/hitlist/logic/commands/AddCommand.java
@@ -71,7 +71,7 @@ public class AddCommand extends Command {
         if (existingWithNumber.isPresent()) {
             throw new CommandException(String.format(
                     MESSAGE_DUPLICATE_PHONE,
-                    toAdd.getName()));
+                    toAdd.getPhone()));
         }
 
         model.addPerson(toAdd);

--- a/src/main/java/hitlist/logic/commands/EditCommand.java
+++ b/src/main/java/hitlist/logic/commands/EditCommand.java
@@ -47,7 +47,8 @@ public class EditCommand extends Command {
     public static final String MESSAGE_EDIT_PERSON_SUCCESS = "Edited Person: %1$s";
     public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";
     public static final String MESSAGE_DUPLICATE_PERSON = "This person already exists in the hitlist.";
-    public static final String MESSAGE_DUPLICATE_CONTACT = "This number is already registered in the hitlist to another person.";
+    public static final String MESSAGE_DUPLICATE_CONTACT =
+            "This number is already registered in the hitlist to another person.";
 
     private final Index index;
     private final EditPersonDescriptor editPersonDescriptor;
@@ -77,14 +78,16 @@ public class EditCommand extends Command {
         Person editedPerson = createEditedPerson(personToEdit, editPersonDescriptor);
 
         boolean isDuplicateName = model.getHitList().getPersonList().stream()
-                .anyMatch(person -> !person.equals(personToEdit) && person.getName().equals(editedPerson.getName()));
+                .anyMatch(person -> !person.equals(personToEdit)
+                        && person.getName().equals(editedPerson.getName()));
 
         if (isDuplicateName) {
             throw new CommandException(MESSAGE_DUPLICATE_PERSON);
         }
 
         boolean isDuplicatePhone = model.getHitList().getPersonList().stream()
-                .anyMatch(person -> !person.equals(personToEdit) && person.getPhone().equals(editedPerson.getPhone()));
+                .anyMatch(person -> !person.equals(personToEdit)
+                        && person.getPhone().equals(editedPerson.getPhone()));
 
         if (isDuplicatePhone) {
             throw new CommandException(MESSAGE_DUPLICATE_CONTACT);

--- a/src/main/java/hitlist/logic/commands/EditCommand.java
+++ b/src/main/java/hitlist/logic/commands/EditCommand.java
@@ -47,6 +47,7 @@ public class EditCommand extends Command {
     public static final String MESSAGE_EDIT_PERSON_SUCCESS = "Edited Person: %1$s";
     public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";
     public static final String MESSAGE_DUPLICATE_PERSON = "This person already exists in the hitlist.";
+    public static final String MESSAGE_DUPLICATE_CONTACT = "This number is already registered in the hitlist to another person.";
 
     private final Index index;
     private final EditPersonDescriptor editPersonDescriptor;
@@ -75,8 +76,18 @@ public class EditCommand extends Command {
         Person personToEdit = lastShownList.get(index.getZeroBased());
         Person editedPerson = createEditedPerson(personToEdit, editPersonDescriptor);
 
-        if (!personToEdit.isSamePerson(editedPerson) && model.hasPerson(editedPerson)) {
+        boolean isDuplicateName = model.getHitList().getPersonList().stream()
+                .anyMatch(person -> !person.equals(personToEdit) && person.getName().equals(editedPerson.getName()));
+
+        if (isDuplicateName) {
             throw new CommandException(MESSAGE_DUPLICATE_PERSON);
+        }
+
+        boolean isDuplicatePhone = model.getHitList().getPersonList().stream()
+                .anyMatch(person -> !person.equals(personToEdit) && person.getPhone().equals(editedPerson.getPhone()));
+
+        if (isDuplicatePhone) {
+            throw new CommandException(MESSAGE_DUPLICATE_CONTACT);
         }
 
         model.setPerson(personToEdit, editedPerson);

--- a/src/main/java/hitlist/model/person/Person.java
+++ b/src/main/java/hitlist/model/person/Person.java
@@ -53,12 +53,17 @@ public class Person {
      * This defines a weaker notion of equality between two persons.
      */
     public boolean isSamePerson(Person otherPerson) {
+        if (otherPerson == null) {
+            return false;
+        }
+
         if (otherPerson == this) {
             return true;
         }
 
         return otherPerson != null
-                && otherPerson.getName().equals(getName());
+                && otherPerson.getName().equals(getName())
+                || otherPerson.getPhone().equals(getPhone());
     }
 
     /**

--- a/src/test/java/hitlist/logic/commands/AddCommandTest.java
+++ b/src/test/java/hitlist/logic/commands/AddCommandTest.java
@@ -70,18 +70,19 @@ public class AddCommandTest {
     }
 
     @Test
-    public void execute_duplicatePersonSamePhoneOnly_success() throws Exception {
+    public void execute_duplicatePersonSamePhoneOnly_throwsCommandException() {
         Person existingPerson = new PersonBuilder(ALICE).withName("Alice Wong").build();
-        Person validPerson = new PersonBuilder()
+        Person duplicatePhonePerson = new PersonBuilder()
                 .withName("Bob").withPhone(existingPerson.getPhone().value).build();
 
         ModelStub modelStub = new ModelStubAcceptingPersonAdded();
         modelStub.addPerson(existingPerson);
 
-        CommandResult commandResult = new AddCommand(validPerson).execute(modelStub);
+        AddCommand addCommand = new AddCommand(duplicatePhonePerson);
 
-        assertEquals(String.format(AddCommand.MESSAGE_SUCCESS, validPerson.getName(), validPerson.getPhone()),
-                commandResult.getFeedbackToUser());
+        assertThrows(CommandException.class,
+                String.format(AddCommand.MESSAGE_DUPLICATE_PHONE, duplicatePhonePerson.getPhone()),
+                () -> addCommand.execute(modelStub));
     }
 
     @Test

--- a/src/test/java/hitlist/logic/commands/AddCommandTest.java
+++ b/src/test/java/hitlist/logic/commands/AddCommandTest.java
@@ -81,8 +81,8 @@ public class AddCommandTest {
         AddCommand addCommand = new AddCommand(duplicatePhonePerson);
 
         assertThrows(CommandException.class,
-                String.format(AddCommand.MESSAGE_DUPLICATE_PHONE, duplicatePhonePerson.getPhone()),
-                () -> addCommand.execute(modelStub));
+                String.format(AddCommand.MESSAGE_DUPLICATE_PHONE, duplicatePhonePerson.getPhone()), ()
+                -> addCommand.execute(modelStub));
     }
 
     @Test

--- a/src/test/java/hitlist/logic/commands/AddCommandTest.java
+++ b/src/test/java/hitlist/logic/commands/AddCommandTest.java
@@ -10,7 +10,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-
 import java.util.Optional;
 
 import org.junit.jupiter.api.Test;
@@ -95,7 +94,7 @@ public class AddCommandTest {
         ModelStubAcceptingPersonAdded modelStub = new ModelStubAcceptingPersonAdded();
         modelStub.addPerson(existingPerson);
 
-        AddCommand addCommand = new AddCommand(duplicatePhonePerson).execute(modelStub);
+        AddCommand addCommand = new AddCommand(duplicatePhonePerson);
 
         String expectedMessage = String.format(
                 AddCommand.MESSAGE_DUPLICATE_PHONE,

--- a/src/test/java/hitlist/logic/commands/AddCommandTest.java
+++ b/src/test/java/hitlist/logic/commands/AddCommandTest.java
@@ -98,7 +98,6 @@ public class AddCommandTest {
 
         String expectedMessage = String.format(
                 AddCommand.MESSAGE_DUPLICATE_PHONE,
-                duplicatePhonePerson.getName(),
                 duplicatePhonePerson.getPhone());
 
         assertThrows(CommandException.class, expectedMessage, () -> addCommand.execute(modelStub));

--- a/src/test/java/hitlist/model/person/PersonTest.java
+++ b/src/test/java/hitlist/model/person/PersonTest.java
@@ -23,26 +23,26 @@ public class PersonTest {
         // same object -> returns true
         assertTrue(ALICE.isSamePerson(ALICE));
 
-        // null -> returns false
-        assertFalse(ALICE.isSamePerson(null));
-
         // same name, all other attributes different -> returns true
         Person editedAlice = new PersonBuilder(ALICE).withPhone(VALID_PHONE_BOB).withEmail(VALID_EMAIL_BOB)
                 .withAddress(VALID_ADDRESS_BOB).build();
         assertTrue(ALICE.isSamePerson(editedAlice));
 
-        // different name, all other attributes same -> returns false
+        // different name, same number, all other attributes same -> returns true
         editedAlice = new PersonBuilder(ALICE).withName(VALID_NAME_BOB).build();
-        assertFalse(ALICE.isSamePerson(editedAlice));
+        assertTrue(ALICE.isSamePerson(editedAlice));
+
+        // null -> returns false
+        assertFalse(ALICE.isSamePerson(null));
 
         // name differs in case, all other attributes same -> returns true
         Person editedBob = new PersonBuilder(BOB).withName(VALID_NAME_BOB.toLowerCase()).build();
         assertTrue(BOB.isSamePerson(editedBob));
 
-        // name has trailing spaces, all other attributes same -> returns false
+        // name has trailing spaces, all other attributes same -> returns true
         String nameWithTrailingSpaces = VALID_NAME_BOB + " ";
         editedBob = new PersonBuilder(BOB).withName(nameWithTrailingSpaces).build();
-        assertFalse(BOB.isSamePerson(editedBob));
+        assertTrue(BOB.isSamePerson(editedBob));
 
         // same name, same phone, all other attributes different -> returns true
         editedAlice = new PersonBuilder(ALICE).withEmail(VALID_EMAIL_BOB)


### PR DESCRIPTION
Currently no check for unique contact

Fix: checks for unique contact throughout hitlist and throw error if not unique