### PR TITLE
Add regression test for duplicate grpassign name prefixes

### DIFF
--- a/src/test/java/hitlist/logic/parser/AssignGroupCommandParserTest.java
+++ b/src/test/java/hitlist/logic/parser/AssignGroupCommandParserTest.java
@@ -34,7 +34,6 @@ public class AssignGroupCommandParserTest {
 
         assertParseSuccess(parser, PREAMBLE_WHITESPACE + NAME_DESC_AMY + GROUP_NAME_DESC_STUDENTS,
                 expectedCommand);
-
         assertParseSuccess(parser, GROUP_NAME_DESC_STUDENTS + NAME_DESC_AMY,
                 expectedCommand);
     }
@@ -43,9 +42,18 @@ public class AssignGroupCommandParserTest {
     public void parse_repeatedPrefixes_failure() {
         assertParseFailure(parser, NAME_DESC_AMY + NAME_DESC_BOB + GROUP_NAME_DESC_STUDENTS,
                 Messages.getErrorMessageForDuplicatePrefixes(PREFIX_NAME));
-
         assertParseFailure(parser, NAME_DESC_AMY + GROUP_NAME_DESC_STUDENTS + GROUP_NAME_DESC_UNEMPLOYED,
                 Messages.getErrorMessageForDuplicatePrefixes(PREFIX_GROUP));
+    }
+
+    @Test
+    public void parse_repeatedNamePrefixesDifferentCasing_failure() {
+        String duplicateNameDifferentCasingInput = " " + PREFIX_NAME + " Alice"
+                + " " + PREFIX_NAME + " alice"
+                + GROUP_NAME_DESC_STUDENTS;
+
+        assertParseFailure(parser, duplicateNameDifferentCasingInput,
+                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_NAME));
     }
 
     @Test
@@ -60,9 +68,7 @@ public class AssignGroupCommandParserTest {
     @Test
     public void parse_invalidValue_failure() {
         assertParseFailure(parser, INVALID_NAME_DESC + GROUP_NAME_DESC_STUDENTS, Name.MESSAGE_CONSTRAINTS);
-
         assertParseFailure(parser, NAME_DESC_AMY + INVALID_GROUP_NAME_DESC, GroupName.MESSAGE_CONSTRAINTS);
-
         assertParseFailure(parser, PREAMBLE_NON_EMPTY + NAME_DESC_AMY + GROUP_NAME_DESC_STUDENTS,
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, AssignGroupCommand.MESSAGE_USAGE));
     }


### PR DESCRIPTION
## Summary
- remove unrelated Name/hashCode changes from PR scope
- add regression coverage for repeated /n prefixes with different casing in grpassign
- verify the parser returns the duplicate-prefix validation error for repeated name prefixes

## Rationale
Issue #265 is already handled at parse time because repeated single-valued prefixes are rejected.
This PR locks in that behavior with an explicit regression test.

## Testing
- .\gradlew.bat test --tests hitlist.logic.parser.AssignGroupCommandParserTest
- .\gradlew.bat check
- .\gradlew.bat coverage